### PR TITLE
Feat: Add support for steam client games import

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Steam.Config;
 using SteamKit2;
 
@@ -82,5 +83,63 @@ static class Disk
         }
 
         return Path.Join(installPath!, folderName);
+    }
+
+    public static async Task<long> GetFolderSizeWithDu(string folderPath)
+    {
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            throw new ArgumentException("Folder path cannot be null or empty.", nameof(folderPath));
+        }
+
+        if (!System.IO.Directory.Exists(folderPath))
+        {
+            throw new System.IO.DirectoryNotFoundException($"The folder '{folderPath}' does not exist.");
+        }
+
+        try
+        {
+            // Set up the process to run `du -sb` for the folder
+            ProcessStartInfo processStartInfo = new ProcessStartInfo
+            {
+                FileName = "du",
+                Arguments = $"-sb \"{folderPath}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using (Process process = Process.Start(processStartInfo)!)
+            {
+                if (process == null)
+                {
+                    throw new InvalidOperationException("Failed to start the 'du' process.");
+                }
+
+                string output = await process.StandardOutput.ReadLineAsync() ?? "";
+                string error = await process.StandardError.ReadToEndAsync();
+
+                await process.WaitForExitAsync();
+
+                if (process.ExitCode != 0)
+                {
+                    throw new Exception($"Error while executing 'du': {error}");
+                }
+
+                // Parse the output (format: "<size_in_bytes>\t<path>")
+                string[] parts = output.Split('\t');
+                if (long.TryParse(parts[0], out long size))
+                {
+                    return size;
+                }
+
+                throw new FormatException("Unexpected output format from 'du'.");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"An error occurred while calculating folder size: {ex.Message}", ex);
+        }
     }
 }

--- a/SteamBus.App/src/Playserve/Manager.cs
+++ b/SteamBus.App/src/Playserve/Manager.cs
@@ -22,6 +22,7 @@ public interface IPluginManager : IDBusObject
     // Methods
     Task<bool> IsPluginRegisteredAsync(string pluginName);
     Task RegisterPluginAsync(string pluginName, ObjectPath pluginPath);
+    Task<DriveInfo[]> GetDrivesAsync();
 
     // Properties
     Task<string> GetVersionAsync();

--- a/SteamBus.App/src/Steam.Cloud/LocalFile.cs
+++ b/SteamBus.App/src/Steam.Cloud/LocalFile.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 namespace Steam.Cloud;
 
 
-class LocalFile
+public class LocalFile
 {
   // File system path to the file
   private readonly string filePath;

--- a/SteamBus.App/src/Steam.Cloud/SteamCloud.cs
+++ b/SteamBus.App/src/Steam.Cloud/SteamCloud.cs
@@ -8,7 +8,7 @@ namespace Steam.Cloud;
 // These are handled by CCloud_ExternalStorageTransferReport_Notification
 // and don't provide any data back to the client.
 
-class SteamCloud(SteamUnifiedMessages steamUnifiedMessages)
+public class SteamCloud(SteamUnifiedMessages steamUnifiedMessages)
 {
   // Handles requests to actual cloud
   private SteamKit2.Internal.Cloud unifiedCloud = steamUnifiedMessages.CreateService<SteamKit2.Internal.Cloud>();

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -282,8 +282,8 @@ public class SteamClientApp
             {
                 var manifestDir = GetManifestDirectory();
                 Directory.CreateDirectory(manifestDir);
-                depotConfigStore.EnsureEntryExists(manifestDir, STEAM_CLIENT_APP_ID);
-                depotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "linux");
+                depotConfigStore.EnsureEntryExists(manifestDir, STEAM_CLIENT_APP_ID, "Steam");
+                depotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "linux", "english");
                 depotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
                 depotConfigStore.Save(STEAM_CLIENT_APP_ID);
 
@@ -330,17 +330,17 @@ public class SteamClientApp
             var info = depotConfigStore.GetInstalledAppInfo(STEAM_CLIENT_APP_ID)?.Info;
             version ??= info?.Version ?? "0";
             totalBytes ??= info?.TotalDownloadSize ?? 0;
-        }
 
-        OnDependencyInstallStarted?.Invoke(new InstallStartedDescription
-        {
-            AppId = STEAM_CLIENT_APP_ID.ToString(),
-            Version = version,
-            InstallDirectory = SteamConfig.GetConfigDirectory(),
-            TotalDownloadSize = (ulong)totalBytes,
-            RequiresInternetConnection = true,
-            Os = "linux",
-        });
+            OnDependencyInstallStarted?.Invoke(new InstallStartedDescription
+            {
+                AppId = STEAM_CLIENT_APP_ID.ToString(),
+                Version = version,
+                InstallDirectory = SteamConfig.GetConfigDirectory(),
+                TotalDownloadSize = (ulong)totalBytes,
+                RequiresInternetConnection = true,
+                Os = "linux",
+            });
+        }
     }
 
     private void OnExited(object? sender, EventArgs e)

--- a/SteamBus.App/src/SteamBus.cs
+++ b/SteamBus.App/src/SteamBus.cs
@@ -2,6 +2,7 @@
 using SteamBus.DBus;
 using System.Reflection;
 using Xdg.Directories;
+using Steam.Config;
 
 namespace SteamBus;
 
@@ -63,11 +64,10 @@ class SteamBus
         "one.playtron.Playserve",
         "/one/playtron/plugins/Manager"
       );
-      await pluginManager.RegisterPluginAsync("one.playtron.SteamBus", path);
 
       await pluginManager.WatchOnDriveAddedAsync(async (driveInfo) =>
       {
-        Console.WriteLine($"Drive:{driveInfo.Name} added");
+        Console.WriteLine($"Drive:{driveInfo.Name} at Path:{driveInfo.Path} added");
         await depotConfigStore.Reload();
         client.EmitInstalledAppsUpdated();
       });
@@ -78,6 +78,17 @@ class SteamBus
         await depotConfigStore.Reload();
         client.EmitInstalledAppsUpdated();
       });
+
+      var drives = await pluginManager.GetDrivesAsync();
+      var libraryConfig = await LibraryFoldersConfig.CreateAsync();
+      foreach (var drive in drives)
+      {
+        Console.WriteLine($"Verifying drive {drive.Name} is in library config");
+        libraryConfig.AddDiskEntry(drive.Path);
+      }
+      libraryConfig.Save();
+
+      await pluginManager.RegisterPluginAsync("one.playtron.SteamBus", path);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
- refactored depot config store to use same acf files as steam to store game info
- properly import games installed by steam client and let steam client recognize games installed by steambus
- fix GetProviderItemAsync and GetProviderItemsAsync errors when user not logged in
- implement new plugin manager call GetDrivesAsync to initialize library folders on start