### PR TITLE
fix: fix external drives not working if mount path has space and expired games showing up in provider items

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Steam.Config;
 using SteamKit2;
@@ -26,12 +27,12 @@ static class Disk
             {
                 var mountPoint = parts[1];
 
-                if (!mountPoint.StartsWith("/sysroot") && !mountPoint.EndsWith(".btrfs") && mountPoint.Length > selectedMountPoint.Length)
+                if (!mountPoint.StartsWith("/sysroot") && !mountPoint.EndsWith(".btrfs") && !mountPoint.StartsWith("/boot") && mountPoint.Length > selectedMountPoint.Length)
                     selectedMountPoint = mountPoint;
             }
         }
 
-        return selectedMountPoint;
+        return Regex.Unescape(selectedMountPoint);
     }
 
     public static async Task<string> GetMountPointFromProc()
@@ -43,7 +44,7 @@ static class Disk
             var parts = line.Split(' ');
             if (IsMountPointMainDisk(parts[1]))
             {
-                return parts[1];
+                return Regex.Unescape(parts[1]);
             }
         }
 

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -1038,8 +1038,9 @@ class ContentDownloader
         Directory.CreateDirectory(Path.Combine(installDir, STAGING_DIR));
       }
     }
-    catch
+    catch (Exception exception)
     {
+      Console.Error.WriteLine($"Error creating directories, ex:{exception}");
       return false;
     }
 

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -869,11 +869,12 @@ public class SteamSession
     // Parse licenses and associate their access tokens
     foreach (var license in licenseList.LicenseList)
     {
+      if ((license.LicenseFlags & ELicenseFlags.Expired) != 0)
+        continue;
+
       packageIds.Add(license.PackageID);
       if (license.AccessToken > 0)
-      {
         PackageTokens.TryAdd(license.PackageID, license.AccessToken);
-      }
     }
     PackageIDs = new ReadOnlyCollection<uint>(packageIds);
 
@@ -882,6 +883,8 @@ public class SteamSession
       libraryCache.SetPackageIDs(SteamUser.SteamID.AccountID, packageIds);
       libraryCache.Save();
     }
+
+    ProviderItemMap.Clear();
 
     Console.WriteLine("Requesting info for {0} packages", packageIds.Count);
     await RequestPackageInfo(packageIds);

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Xdg.Directories;
 using Steam.Config;
 using Steam.Cloud;
+using System.Text.RegularExpressions;
 
 namespace SteamBus.DBus;
 
@@ -619,7 +620,8 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
 
     // Configure the download options
     var installdir = await downloader.GetAppInstallDir(appId);
-    var downloadOptions = new AppDownloadOptions(options, await Disk.GetInstallRootFromDevice(disk, installdir));
+    var installFolder = await Disk.GetInstallRootFromDevice(disk, installdir);
+    var downloadOptions = new AppDownloadOptions(options, installFolder);
 
     // Start downloading the app
     try

--- a/SteamBus.App/src/SteamBus.cs
+++ b/SteamBus.App/src/SteamBus.cs
@@ -3,6 +3,7 @@ using SteamBus.DBus;
 using System.Reflection;
 using Xdg.Directories;
 using Steam.Config;
+using System.Text.RegularExpressions;
 
 namespace SteamBus;
 
@@ -84,7 +85,7 @@ class SteamBus
       foreach (var drive in drives)
       {
         Console.WriteLine($"Verifying drive {drive.Name} is in library config");
-        libraryConfig.AddDiskEntry(drive.Path);
+        libraryConfig.AddDiskEntry(Regex.Unescape(drive.Path));
       }
       libraryConfig.Save();
 


### PR DESCRIPTION
- fix: when external drives mount path had a space such as `/run/media/Test 1`, the sub directory was not able to be created due to how the space was encoded with `\040`
- fix: expired games no longer show up in ProviderItems call