### PR TITLE
fix: local builds with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ in-docker:
 	@# Run the given make target inside Docker
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
 	docker run --rm \
-		-v $(PWD):/src:Z \
+		-v $(shell pwd):/src:Z \
 		--workdir /src \
 		--user $(shell id -u):$(shell id -g) \
 		-e DOTNET_CLI_HOME=/tmp \


### PR DESCRIPTION
The PWD variable in the Makefile does not seem very portable. At least, it does not work on my machine despite working in CI. Instead, invoke the 'pwd' command via a shell.