### PR TITLE
fix: app updaterequired state flag not being removed after download

### DIFF
--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -452,10 +452,13 @@ public class DepotConfigStore
                 break;
         }
 
-        manifestMap[appId][KEY_STATE_FLAGS] = new KeyValue(KEY_STATE_FLAGS, ((int)stateFlags).ToString());
-
-        if ((stateFlags & StateFlags.FullyInstalled) != 0)
+        if (stage == null)
+        {
             manifestMap[appId][KEY_LAST_UPDATED] = new KeyValue(KEY_LAST_UPDATED, DateTimeOffset.Now.ToUnixTimeSeconds().ToString());
+            stateFlags &= ~StateFlags.UpdateRequired;
+        }
+
+        manifestMap[appId][KEY_STATE_FLAGS] = new KeyValue(KEY_STATE_FLAGS, ((int)stateFlags).ToString());
 
         if (sizeOnDisk != null)
             UpdateAppSizeOnDisk(appId, (ulong)sizeOnDisk);


### PR DESCRIPTION
This was causing games to constantly being in the update required state after restarting