### PR TITLE
Fix/external disk

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -82,7 +82,7 @@ static class Disk
                 string[] parts = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length < 6)
                     continue;
-                var path = parts[5];
+                var path = string.Join(" ", parts[5..]);
 
                 var condition = driveName == null ? IsMountPointMainDisk(path) : line.StartsWith(driveName);
 


### PR DESCRIPTION
Fixes failures to install and move Steam games to external media that have a space in their path.

The issue was the handling of `df` output using the Split operator on the space (' ') character which also splits up the file path. The logic was grabbing the first element of the path up to the first space.

The change reconstructs the original path by joining all the elements of the path together.