### PR TITLE
fix: SyncInstalledAppsAsync now happens immediatelly and always sync OS config for installed games

### DIFF
--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -137,6 +137,8 @@ public class DepotConfigStore
 
     public SteamSession? steamSession;
 
+    private readonly SemaphoreSlim fileLock = new(1, 1);
+
     DepotConfigStore()
     {
         appInfoCache = new AppInfoCache(AppInfoCache.DefaultPath());
@@ -202,13 +204,15 @@ public class DepotConfigStore
 
     public async Task<bool> ImportApp(string manifestPath)
     {
-        if (manifestPathMap.Any((pair) => pair.Value == manifestPath))
-            return false;
-
-        var manifestExtraPath = manifestPath.Replace(".acf", ".extra.acf");
+        await fileLock.WaitAsync();
 
         try
         {
+            if (manifestPathMap.Any((pair) => pair.Value == manifestPath))
+                return false;
+
+            var manifestExtraPath = manifestPath.Replace(".acf", ".extra.acf");
+
             var manifestData = await File.ReadAllTextAsync(manifestPath);
             if (string.IsNullOrEmpty(manifestData))
                 return false;
@@ -263,6 +267,37 @@ public class DepotConfigStore
         {
             Console.Error.WriteLine($"Error when importing app, err:{err}");
             return false;
+        }
+        finally
+        {
+            fileLock.Release();
+        }
+    }
+
+    public void VerifyAppsOsConfig(uint accountId)
+    {
+        var globalConfig = new GlobalConfig(GlobalConfig.DefaultPath());
+        var userCompatConfig = accountId == 0 ? null : new UserCompatConfig(UserCompatConfig.DefaultPath(accountId));
+
+        foreach (var appId in manifestMap.Keys)
+            VerifyAppsOsConfig(globalConfig, userCompatConfig, appId);
+
+        globalConfig.Save();
+        userCompatConfig?.Save();
+    }
+
+    public void VerifyAppsOsConfig(GlobalConfig globalConfig, UserCompatConfig? userCompatConfig, uint appId)
+    {
+        var osFromDepots = TryGetOsFromDepots(appId);
+        var defaultOs = ContentDownloader.GetSteamOS();
+
+        if (osFromDepots != null && defaultOs != osFromDepots)
+        {
+            if (userCompatConfig != null)
+                userCompatConfig.SetPlatformOverride(appId, defaultOs, osFromDepots);
+
+            if (osFromDepots == "windows")
+                globalConfig.SetProton9CompatForApp(appId);
         }
     }
 
@@ -874,6 +909,13 @@ public class DepotConfigStore
     {
         if (appIdToOsMap.TryGetValue(appId, out var os)) return os;
 
+        var osFound = TryGetOsFromDepots(appId);
+        if (osFound != null)
+        {
+            appIdToOsMap[appId] = osFound;
+            return osFound;
+        }
+
         if (currentAccountId != null)
         {
             var userCompatConfig = GetUserCompatConfig((uint)currentAccountId);
@@ -884,14 +926,7 @@ public class DepotConfigStore
 
         var lastOwner = manifestMap[appId][KEY_LAST_OWNER]?.AsUnsignedLong();
         var accountId = lastOwner == null ? 0 : (uint)(lastOwner! & 0xFFFFFFFF);
-        if (accountId == 0)
-        {
-            var osFound = TryGetOsFromDepots(appId);
-            if (osFound == null) return null;
-
-            appIdToOsMap[appId] = osFound;
-            return osFound;
-        }
+        if (accountId == 0) return null;
 
         var lastOwnerConfig = GetUserCompatConfig(accountId);
         var lastOwnerOs = lastOwnerConfig.GetAppPlatform(appId);

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -61,7 +61,7 @@ public class SteamClientApp
         return $"{BaseDirectory.DataHome}/steambus/tools/steam";
     }
 
-    public async Task Start(string forAppId, string username, bool offlineMode)
+    public async Task Start(uint accountId, string forAppId, string username, bool offlineMode)
     {
         this.forAppId = forAppId;
 
@@ -87,6 +87,9 @@ public class SteamClientApp
         loginFailed = false;
         readyTask = new();
         steamuiLogs.Delete();
+
+        // Verify all installed apps have correct config so steam client does not set them to update pending
+        depotConfigStore.VerifyAppsOsConfig(accountId);
 
         var arguments = new List<string>(ARGUMENTS);
 


### PR DESCRIPTION
- changed SyncInstalledAppsAsync to happen immediatelly since it has no need to wait on session to exist
- sync OS config for installed games so steam client doesn't pick wrong OS/platform and mark the game as update needed