### PR TITLE
feat: handle download of dlcs

### DIFF
--- a/SteamBus.App/src/Steam.Config/AppInfoCache.cs
+++ b/SteamBus.App/src/Steam.Config/AppInfoCache.cs
@@ -62,21 +62,12 @@ public class AppInfoCache
     {
         try
         {
-            string content = "";
-            using (var stream = File.OpenText(GetFinalPath(appId)))
-            {
-                string? line;
-                while ((line = stream.ReadLine()) != null)
-                {
-                    content += line;
-                }
-            }
-
+            var content = Disk.ReadFileWithRetry(GetFinalPath(appId));
             return KeyValue.LoadFromString(content);
         }
-        catch (Exception)
+        catch (Exception err)
         {
-            Console.WriteLine("Failed to read cache for {0}", appId);
+            Console.WriteLine($"Failed to read cache for {appId}, err:{err}");
             return null;
         }
     }

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -364,7 +364,8 @@ public class SteamClientApp
 
     private void OnExited(object? sender, EventArgs e)
     {
-        depotConfigStore.VerifyAppsStateFlag();
+        // Reload depot config store in case steam client changed the manifests
+        _ = depotConfigStore.Reload();
 
         Console.WriteLine($"Steam client exited with code {process?.ExitCode}");
         process = null;


### PR DESCRIPTION
- download all dlc depots that are owned and respect DisableDLC field in app manifest
- retry reading app info cache file if the file is locked
- examine all installed app depots when user is logged in to check if apps need update or are fully downloaded
- remove random Abort calls when download errors happen
- call SaveToken on begin of OnLogIn to avoid lost refreshed tokens
- reload depot config store on steam client exit
- fix cleaning up previously downloaded depots even if it is still needed when starting download
- send install failed signals in some cases where download is cancelled