### PR TITLE
Fix: Make sure installed apps initialize properly for external drives

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -10,7 +10,7 @@ static class Disk
 
     public static bool IsMountPointMainDisk(string mountPoint)
     {
-        return mountPoint == "/" || mountPoint == "/home" || mountPoint == "/var/home";
+        return mountPoint == "/" || mountPoint.StartsWith("/home") || mountPoint.StartsWith("/var/home");
     }
 
     static async Task<string> RunDf(string arg)
@@ -64,7 +64,7 @@ static class Disk
         return _homeDrive;
     }
 
-    static async Task<string> GetMountPath(string? driveName = null)
+    public static async Task<string> GetMountPath(string? driveName = null)
     {
         var homePath = Regex.Unescape(Environment.GetEnvironmentVariable("HOME") ?? string.Empty);
         if (driveName == null) return homePath;

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -1015,13 +1015,6 @@ public class DepotConfigStore
     {
         if (appIdToOsMap.TryGetValue(appId, out var os) && os != null) return os;
 
-        var osFound = TryGetOsFromDepots(appId);
-        if (osFound != null)
-        {
-            appIdToOsMap[appId] = osFound;
-            return osFound;
-        }
-
         if (currentAccountId != null)
         {
             var userCompatConfig = GetUserCompatConfig((uint)currentAccountId);
@@ -1032,12 +1025,19 @@ public class DepotConfigStore
 
         var lastOwner = manifestMap[appId][KEY_LAST_OWNER]?.AsUnsignedLong();
         var accountId = lastOwner == null ? 0 : (uint)(lastOwner! & 0xFFFFFFFF);
-        if (accountId == 0) return "";
 
-        var lastOwnerConfig = GetUserCompatConfig(accountId);
-        var lastOwnerOs = lastOwnerConfig.GetAppPlatform(appId);
-        appIdToOsMap[appId] = lastOwnerOs;
-        return lastOwnerOs ?? "";
+        if (accountId != 0)
+        {
+            var lastOwnerConfig = GetUserCompatConfig(accountId);
+            var lastOwnerOs = lastOwnerConfig.GetAppPlatform(appId);
+            appIdToOsMap[appId] = lastOwnerOs;
+            if (lastOwnerOs != null) return lastOwnerOs;
+        }
+
+        var osFound = TryGetOsFromDepots(appId);
+        if (osFound != null)
+            appIdToOsMap[appId] = osFound;
+        return osFound ?? "";
     }
 
     private string? TryGetOsFromDepots(uint appId)

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -190,7 +190,7 @@ public class DepotConfigStore
         }
     }
 
-    private async Task ReloadApps(string dir)
+    public async Task ReloadApps(string dir)
     {
         var commonDir = Path.Join(dir, "common");
         if (!Directory.Exists(dir) || !Directory.Exists(commonDir))

--- a/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
@@ -94,8 +94,8 @@ public class LibraryFoldersConfig
         else
             await CreateFile();
 
-        var mainMountPath = SteamConfig.GetConfigDirectory();
-        var hasMainMountPath = data?.Children.Any((c) => c["path"]?.AsString() == mainMountPath) ?? false;
+        var configDir = SteamConfig.GetConfigDirectory();
+        var hasMainMountPath = data?.Children.Any((c) => c["path"]?.AsString() == configDir) ?? false;
         if (!hasMainMountPath)
         {
             AddDiskEntry(await Disk.GetMountPath());

--- a/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
@@ -64,12 +64,7 @@ public class LibraryFoldersConfig
     public static async Task<LibraryFoldersConfig> CreateAsync()
     {
         var config = new LibraryFoldersConfig(DefaultPath());
-
-        if (File.Exists(config.path))
-            await config.Reload();
-        else
-            await config.CreateFile();
-
+        await config.Reload();
         return config;
     }
 
@@ -89,11 +84,23 @@ public class LibraryFoldersConfig
     /// <returns></returns>
     public async Task Reload()
     {
-        var stream = File.OpenText(this.path);
-        var content = await stream.ReadToEndAsync();
+        if (File.Exists(path))
+        {
+            var stream = File.OpenText(this.path);
+            var content = await stream.ReadToEndAsync();
+            this.data = KeyValue.LoadFromString(content);
+            stream.Close();
+        }
+        else
+            await CreateFile();
 
-        this.data = KeyValue.LoadFromString(content);
-        stream.Close();
+        var mainMountPath = SteamConfig.GetConfigDirectory();
+        var hasMainMountPath = data?.Children.Any((c) => c["path"]?.AsString() == mainMountPath) ?? false;
+        if (!hasMainMountPath)
+        {
+            AddDiskEntry(await Disk.GetMountPath());
+            Save();
+        }
     }
 
     /// <summary>
@@ -115,6 +122,9 @@ public class LibraryFoldersConfig
     {
         Disk.EnsureParentFolderExists(path);
         this.data?.SaveToFile(this.path, false);
+
+        var otherPath = Path.Join(SteamConfig.GetConfigDirectory(), "steamapps", FILENAME);
+        this.data?.SaveToFile(otherPath, false);
     }
 
     /// <summary>
@@ -150,17 +160,7 @@ public class LibraryFoldersConfig
         if (!Directory.Exists(steamappsFolder))
             Directory.CreateDirectory(steamappsFolder);
 
-        if (isMainDisk)
-        {
-            var steamappsFileLink = Path.Join(steamappsFolder, FILENAME);
-
-            if (File.Exists(steamappsFileLink) || Directory.Exists(steamappsFileLink))
-                File.Delete(steamappsFileLink);
-
-            Disk.EnsureParentFolderExists(steamappsFileLink);
-            File.CreateSymbolicLink(steamappsFileLink, path);
-        }
-        else
+        if (!isMainDisk)
         {
             var externalLibraryFoldersConfigFile = Path.Join(installPath, EXTERNAL_FILENAME);
 

--- a/SteamBus.App/src/SteamBus.cs
+++ b/SteamBus.App/src/SteamBus.cs
@@ -94,6 +94,10 @@ class SteamBus
       }
       libraryConfig.Save();
 
+      var directories = libraryConfig.GetInstallDirectories();
+      foreach (var dir in directories)
+        await depotConfigStore.ReloadApps(dir);
+
       await pluginManager.RegisterPluginAsync("one.playtron.SteamBus", path);
     }
     catch (Exception ex)


### PR DESCRIPTION
- reload depot config store for new drives on initialization
- initialize library folders correctly if it does not exist or is empty
  - got rid of symlink logic, seems like steam saves libraryapps.vdf in 2 places, its not a symlink