### PR TITLE
fix: save installed os into extra data config for games

### DIFF
--- a/SteamBus.App/src/Steam.Config/GlobalConfig.cs
+++ b/SteamBus.App/src/Steam.Config/GlobalConfig.cs
@@ -123,9 +123,14 @@ public class GlobalConfig
             this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr] = new KeyValue(appIdStr);
         }
 
-        this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_NAME] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_NAME, "proton_9");
-        this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_CONFIG] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_CONFIG, "");
-        this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_PRIORITY] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_PRIORITY, "250");
+        // Set proton_9 tool config so steam client identifies game as windows installation
+        var toolName = this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_NAME]?.AsString();
+        if (string.IsNullOrEmpty(toolName) || !toolName.Contains("proton"))
+        {
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_NAME] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_NAME, "proton_9");
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_CONFIG] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_CONFIG, "");
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_PRIORITY] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_PRIORITY, "250");
+        }
     }
 
     void EnsureRootKeysExist()

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -293,7 +293,7 @@ class ContentDownloader
       {
         Console.WriteLine("Using LanCache server for downloads");
       }
-      cdnPool = new CDNClientPool(this.session.SteamClient, appId);
+      cdnPool = new CDNClientPool(this.session.SteamClient, appId, onInstallFailed);
       var cts = new CancellationTokenSource();
       cdnPool!.ExhaustedToken = cts;
 
@@ -361,7 +361,7 @@ class ContentDownloader
         var steamId = session.SteamUser?.SteamID?.ConvertToUInt64();
 
         depotConfigStore.EnsureEntryExists(options.InstallDirectory, appId, GetAppName(appId));
-        depotConfigStore.SetNewVersion(appId, version, branch, language ?? "", steamId.ToString());
+        depotConfigStore.SetNewVersion(appId, version, branch, language ?? "", os, steamId.ToString());
 
         await DownloadSteam3Async(appId, infos, cts, installStartedData).ConfigureAwait(false);
         onInstallCompleted?.Invoke(appId.ToString());

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -302,7 +302,7 @@ public class SteamClientApp
                 var manifestDir = GetManifestDirectory();
                 Directory.CreateDirectory(manifestDir);
                 depotConfigStore.EnsureEntryExists(manifestDir, STEAM_CLIENT_APP_ID, "Steam");
-                depotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "linux", "english");
+                depotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "english", "linux");
                 depotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
                 depotConfigStore.Save(STEAM_CLIENT_APP_ID);
 

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -507,6 +507,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
   {
     if (ParseAppId(appIdString) is not uint appId) throw DbusExceptionHelper.ThrowInvalidAppId();
     if ((session == null || !session.IsPendingLogin) && !EnsureConnected()) throw DbusExceptionHelper.ThrowNotLoggedIn();
+    if (fetchingSteamClientData != null) await fetchingSteamClientData.Task;
 
     if (!session!.IsPendingLogin)
       await session!.RequestAppInfo(appId, false);
@@ -675,6 +676,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     Console.WriteLine($"Installing app: {appIdString}");
     if (!EnsureConnected()) throw DbusExceptionHelper.ThrowNotLoggedIn();
     if (ParseAppId(appIdString) is not uint appId) throw DbusExceptionHelper.ThrowInvalidAppId();
+    if (fetchingSteamClientData != null) await fetchingSteamClientData.Task;
 
     // Create a content downloader for the given app
     var downloader = new ContentDownloader(session!, depotConfigStore);
@@ -1296,7 +1298,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
 
           if (!success) Console.Error.WriteLine($"Steam has not generated user files...");
 
-          await steamClientApp.ShutdownSteamWithTimeoutAsync(TimeSpan.FromSeconds(5));
+          await steamClientApp.ShutdownSteamWithTimeoutAsync(TimeSpan.FromSeconds(10));
           Console.WriteLine("Shut down steam client after fetching data");
         }
         catch (Exception err)


### PR DESCRIPTION
- save installed os into extra data config for games
  - reason for this change being that for games installed in an external disk, the steam client has no way to identify whether it should use the windows or linux version if running on a linux system. this is because the user config for forcing the proton on the game is stored in the main drive, and if the user config is cleared out, that game would be identifier as linux even though windows version might be installed
- properly notify if install fails due to cdn client pool error
- dont overwrite proton version if user already has it defined
- increase initial steam client timeout to 10 seconds instead of 5

