### PR TITLE
feat: refactor of download functionality

### DIFF
--- a/SteamBus.App/src/Core/Extensions.cs
+++ b/SteamBus.App/src/Core/Extensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using SteamKit2;
 
 public static class EnumExtensions
 {
@@ -10,5 +11,25 @@ public static class EnumExtensions
         FieldInfo? field = value.GetType().GetField(value.ToString());
         DescriptionAttribute? attribute = field?.GetCustomAttribute<DescriptionAttribute>();
         return attribute?.Description ?? value.ToString();
+    }
+}
+
+public static class KeyValueExtensions
+{
+    // This is needed because since KeyValue.SaveToFile writes data recursively, if the program is killed the file will be left in an invalid state
+    public static void SaveToFileWithAtomicRename(this KeyValue keyValue, string filePath)
+    {
+        string tempFilePath = filePath + ".temp";
+
+        try
+        {
+            keyValue.SaveToFile(tempFilePath, false);
+            File.Move(tempFilePath, filePath, true);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error occurred saving KeyValue file {filePath}: {ex.Message}");
+            throw;
+        }
     }
 }

--- a/SteamBus.App/src/Steam.Config/AppInfoCache.cs
+++ b/SteamBus.App/src/Steam.Config/AppInfoCache.cs
@@ -47,7 +47,7 @@ public class AppInfoCache
                 else
                 {
                     Directory.CreateDirectory(path);
-                    data.SaveToFile(finalPath, false);
+                    data.SaveToFileWithAtomicRename(finalPath);
                 }
             }
             catch (Exception exception)

--- a/SteamBus.App/src/Steam.Config/DownloadFileConfig.cs
+++ b/SteamBus.App/src/Steam.Config/DownloadFileConfig.cs
@@ -1,0 +1,154 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Playtron.Plugin;
+using SteamKit2;
+using Xdg.Directories;
+
+
+namespace Steam.Config;
+
+public class DownloadFileConfigData
+{
+    required public string Version;
+    required public int ChunkCount;
+    required public HashSet<string> DownloadedChunks;
+}
+
+public class DownloadFileConfig
+{
+    public string configDir;
+
+    private const string ROOT_NAME = "DownloadFileConfig";
+    private const string KEY_VERSION = "version";
+    private const string KEY_CHUNK_COUNT = "chunk_count";
+    private const string KEY_CHUNKS_DOWNLOADED_COUNT = "chunk_downloaded_count";
+    private const string KEY_DOWNLOADED_CHUNKS = "downloaded_chunks";
+
+    private ConcurrentDictionary<string, KeyValue> dataMap = new();
+    private static readonly ConcurrentDictionary<string, object> FileLocks = new ConcurrentDictionary<string, object>();
+
+    public DownloadFileConfig(string configDir)
+    {
+        this.configDir = configDir;
+        Directory.CreateDirectory(configDir);
+    }
+
+    public DownloadFileConfigData? Get(string filePath)
+    {
+        object fileLock = FileLocks.GetOrAdd(filePath, new object());
+        lock (fileLock)
+        {
+            if (dataMap.TryGetValue(filePath, out var data))
+                return KeyValueToData(data);
+
+            var keyValue = KeyValue.LoadAsText(GetSavePath(filePath));
+            if (keyValue != null)
+            {
+                dataMap[filePath] = keyValue;
+                return KeyValueToData(keyValue);
+            }
+
+            return null;
+        }
+    }
+
+    public void SetAllocated(string filePath, string version, int chunkCount)
+    {
+        object fileLock = FileLocks.GetOrAdd(filePath, new object());
+        lock (fileLock)
+        {
+            var data = GetKeyValuesOrCreate(filePath);
+            data[KEY_VERSION] = new KeyValue(KEY_VERSION, version);
+            data[KEY_CHUNK_COUNT] = new KeyValue(KEY_CHUNK_COUNT, chunkCount.ToString());
+            data[KEY_CHUNKS_DOWNLOADED_COUNT] = new KeyValue(KEY_CHUNKS_DOWNLOADED_COUNT, "0");
+            data[KEY_DOWNLOADED_CHUNKS] = new KeyValue(KEY_DOWNLOADED_CHUNKS);
+            Save(filePath, data);
+        }
+    }
+
+    public void SetChunkDownloaded(string filePath, string chunkID)
+    {
+        if (string.IsNullOrEmpty(chunkID)) return;
+
+        object fileLock = FileLocks.GetOrAdd(filePath, new object());
+        lock (fileLock)
+        {
+            var data = GetKeyValuesOrCreate(filePath);
+            data[KEY_DOWNLOADED_CHUNKS][chunkID] = new KeyValue(chunkID, "1");
+            data[KEY_CHUNKS_DOWNLOADED_COUNT] = new KeyValue(KEY_CHUNKS_DOWNLOADED_COUNT, data[KEY_DOWNLOADED_CHUNKS].Children.Count.ToString());
+            Save(filePath, data);
+        }
+    }
+
+    public void SetChunksDownloaded(string filePath, string version, int chunkCount, IEnumerable<string> chunkIDs)
+    {
+        object fileLock = FileLocks.GetOrAdd(filePath, new object());
+        lock (fileLock)
+        {
+            var data = GetKeyValuesOrCreate(filePath);
+            data[KEY_VERSION] = new KeyValue(KEY_VERSION, version);
+            data[KEY_CHUNK_COUNT] = new KeyValue(KEY_CHUNK_COUNT, chunkCount.ToString());
+            data[KEY_DOWNLOADED_CHUNKS] = new KeyValue(KEY_DOWNLOADED_CHUNKS);
+            foreach (var chunkID in chunkIDs)
+                if (!string.IsNullOrEmpty(chunkID))
+                    data[KEY_DOWNLOADED_CHUNKS][chunkID] = new KeyValue(chunkID, "1");
+            data[KEY_CHUNKS_DOWNLOADED_COUNT] = new KeyValue(KEY_CHUNKS_DOWNLOADED_COUNT, data[KEY_DOWNLOADED_CHUNKS].Children.Count.ToString());
+            Save(filePath, data);
+        }
+    }
+
+    public void Remove()
+    {
+        if (Directory.Exists(configDir))
+            Directory.Delete(configDir, true);
+    }
+
+    public void Remove(string filePath)
+    {
+        var finalPath = GetSavePath(filePath);
+        if (File.Exists(finalPath))
+            File.Delete(finalPath);
+        dataMap.TryRemove(filePath, out var _);
+    }
+
+    private KeyValue GetKeyValuesOrCreate(string filePath)
+    {
+        if (dataMap.TryGetValue(filePath, out var data))
+            return data;
+
+        var keyValue = KeyValue.LoadAsText(GetSavePath(filePath));
+        if (keyValue != null)
+        {
+            dataMap[filePath] = keyValue;
+            return keyValue;
+        }
+
+        var newData = new KeyValue(ROOT_NAME);
+        newData[KEY_DOWNLOADED_CHUNKS] = new KeyValue(KEY_DOWNLOADED_CHUNKS);
+        dataMap[filePath] = newData;
+        return newData;
+    }
+
+    private void Save(string filePath, KeyValue data)
+    {
+        var finalPath = GetSavePath(filePath);
+        Disk.EnsureParentFolderExists(finalPath);
+        data.SaveToFileWithAtomicRename(finalPath);
+    }
+
+    private string GetSavePath(string filePath) => Path.Join(configDir, filePath);
+
+    private DownloadFileConfigData KeyValueToData(KeyValue keyValue)
+    {
+        var downloadedChunks = keyValue[KEY_DOWNLOADED_CHUNKS].Children.Select((child) => child.Name!).ToHashSet();
+
+        return new DownloadFileConfigData
+        {
+            Version = keyValue[KEY_VERSION].AsString()!,
+            ChunkCount = keyValue[KEY_CHUNK_COUNT].AsInteger(),
+            DownloadedChunks = downloadedChunks,
+        };
+    }
+}
+

--- a/SteamBus.App/src/Steam.Config/GlobalConfig.cs
+++ b/SteamBus.App/src/Steam.Config/GlobalConfig.cs
@@ -83,7 +83,7 @@ public class GlobalConfig
     public void Save()
     {
         Disk.EnsureParentFolderExists(path);
-        this.data?.SaveToFile(this.path, false);
+        this.data?.SaveToFileWithAtomicRename(this.path);
     }
 
     // Add the given steam username and ID to the config file
@@ -108,7 +108,7 @@ public class GlobalConfig
     }
 
     // Sets proton 9 as compat tool for an app id
-    public void SetProton9CompatForApp(uint appId)
+    public void SetProton9CompatForApp(uint appId, uint priority = 250)
     {
         EnsureRootKeysExist();
 
@@ -125,11 +125,13 @@ public class GlobalConfig
 
         // Set proton_9 tool config so steam client identifies game as windows installation
         var toolName = this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_NAME]?.AsString();
-        if (string.IsNullOrEmpty(toolName) || !toolName.Contains("proton"))
+
+        // Override if tool is not proton already or if appId is 0, meaning it applies to all titles
+        if (string.IsNullOrEmpty(toolName) || !toolName.Contains("proton") || appId == 0)
         {
             this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_NAME] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_NAME, "proton_9");
             this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_CONFIG] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_CONFIG, "");
-            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_PRIORITY] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_PRIORITY, "250");
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_PRIORITY] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_PRIORITY, priority.ToString());
         }
     }
 

--- a/SteamBus.App/src/Steam.Config/LibraryCache.cs
+++ b/SteamBus.App/src/Steam.Config/LibraryCache.cs
@@ -57,7 +57,7 @@ public class LibraryCache
     public void Save()
     {
         Disk.EnsureParentFolderExists(path);
-        this.data?.SaveToFile(this.path, false);
+        this.data?.SaveToFileWithAtomicRename(this.path);
     }
 
     // Adds the list of package ids to the cache
@@ -88,7 +88,7 @@ public class LibraryCache
     }
 
     // Adds the list of apps to the cache
-    public void SetApps(uint identifier, IEnumerable<ProviderItem> providerItems)
+    public void SetApps(uint identifier, List<ProviderItem> providerItems)
     {
         var identifierStr = identifier.ToString();
 

--- a/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
@@ -121,10 +121,10 @@ public class LibraryFoldersConfig
     public void Save()
     {
         Disk.EnsureParentFolderExists(path);
-        this.data?.SaveToFile(this.path, false);
+        this.data?.SaveToFileWithAtomicRename(this.path);
 
         var otherPath = Path.Join(SteamConfig.GetConfigDirectory(), "steamapps", FILENAME);
-        this.data?.SaveToFile(otherPath, false);
+        this.data?.SaveToFileWithAtomicRename(otherPath);
     }
 
     /// <summary>
@@ -168,7 +168,7 @@ public class LibraryFoldersConfig
             {
                 var singleEntry = KeyValue.LoadFromString(DEFAULT_EXTERNAL_LIBRARY_FOLDERS_CONTENT)!;
                 Disk.EnsureParentFolderExists(externalLibraryFoldersConfigFile);
-                singleEntry.SaveToFile(externalLibraryFoldersConfigFile, false);
+                singleEntry.SaveToFileWithAtomicRename(externalLibraryFoldersConfigFile);
             }
         }
 

--- a/SteamBus.App/src/Steam.Config/LocalConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LocalConfig.cs
@@ -69,7 +69,7 @@ public class LocalConfig
   public void Save()
   {
     Disk.EnsureParentFolderExists(path);
-    this.data?.SaveToFile(this.path, false);
+    this.data?.SaveToFileWithAtomicRename(this.path);
   }
 
   // Add the given refresh token to the 'ConnectCache' section of the 'MachineUserConfigStore'

--- a/SteamBus.App/src/Steam.Config/LoginUsersConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LoginUsersConfig.cs
@@ -63,7 +63,7 @@ public class LoginUsersConfig
     public void Save()
     {
         Disk.EnsureParentFolderExists(path);
-        this.data?.SaveToFile(this.path, false);
+        this.data?.SaveToFileWithAtomicRename(this.path);
     }
 
     // Add the given user to the loginusers config
@@ -129,7 +129,7 @@ public class LoginUsersConfig
             Directory.CreateDirectory(parent);
             return (new KeyValue("users"), userConfigPath);
         }
-        
+
         return (KeyValue.LoadAsText(userConfigPath) ?? new KeyValue("users"), userConfigPath);
     }
 
@@ -138,7 +138,7 @@ public class LoginUsersConfig
         var (userData, path) = GetUserConfig(accountId);
         userData = UpdateUserConfig(userData);
         Disk.EnsureParentFolderExists(path);
-        userData.SaveToFile(path, false);
+        userData.SaveToFileWithAtomicRename(path);
     }
 
     private KeyValue UpdateUserConfig(KeyValue data)
@@ -172,7 +172,7 @@ public class LoginUsersConfig
         if (!File.Exists(userSharedConfigPath))
         {
             var newSharedConfigData = UpdateUserSharedConfig(new KeyValue("UserRoamingConfigStore"));
-            newSharedConfigData.SaveToFile(userSharedConfigPath, false);
+            newSharedConfigData.SaveToFileWithAtomicRename(userSharedConfigPath);
             return;
         }
 
@@ -181,7 +181,7 @@ public class LoginUsersConfig
         var userSharedConfigData = KeyValue.LoadFromString(content)!;
         stream.Close();
         userSharedConfigData = UpdateUserSharedConfig(userSharedConfigData);
-        userSharedConfigData.SaveToFile(userSharedConfigPath, false);
+        userSharedConfigData.SaveToFileWithAtomicRename(userSharedConfigPath);
     }
 
     private KeyValue UpdateUserSharedConfig(KeyValue data)

--- a/SteamBus.App/src/Steam.Config/RemoteCache.cs
+++ b/SteamBus.App/src/Steam.Config/RemoteCache.cs
@@ -144,7 +144,7 @@ public class RemoteCache
 			Console.WriteLine("Failed to create directory for remotecache file");
 		}
 		// We want to raise this exception to trigger potential failures
-		data.SaveToFile(this.path, false);
+		data.SaveToFileWithAtomicRename(this.path);
 	}
 
 	public static string GetRemoteCachePath(uint userid, uint appid)

--- a/SteamBus.App/src/Steam.Config/SteamuiLogs.cs
+++ b/SteamBus.App/src/Steam.Config/SteamuiLogs.cs
@@ -9,7 +9,6 @@ namespace Steam.Config;
 
 public class SteamuiLogs
 {
-    private KeyValue? data;
     public string path;
     public const string filename = "steamui_login.txt";
 

--- a/SteamBus.App/src/Steam.Config/UserCache.cs
+++ b/SteamBus.App/src/Steam.Config/UserCache.cs
@@ -53,7 +53,7 @@ public class UserCache
     public void Save()
     {
         Disk.EnsureParentFolderExists(path);
-        this.data?.SaveToFile(this.path, false);
+        this.data?.SaveToFileWithAtomicRename(this.path);
     }
 
     // Add the value to the cache

--- a/SteamBus.App/src/Steam.Config/UserCompatConfig.cs
+++ b/SteamBus.App/src/Steam.Config/UserCompatConfig.cs
@@ -73,7 +73,7 @@ public class UserCompatConfig
         Disk.EnsureParentFolderExists(path);
         Disk.ExecuteFileOpWithRetry(() =>
         {
-            this.data?.SaveToFile(this.path, false);
+            this.data?.SaveToFileWithAtomicRename(this.path);
             return "";
         }, this.path);
     }

--- a/SteamBus.App/src/Steam.Content/DownloadConfig.cs
+++ b/SteamBus.App/src/Steam.Content/DownloadConfig.cs
@@ -8,7 +8,7 @@ using Playtron.Plugin;
 
 namespace Steam.Content;
 
-class AppDownloadOptions
+public class AppDownloadOptions
 {
   public const string DEFAULT_BRANCH = "public";
 

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -93,6 +93,11 @@ public class SteamClientApp
         if (!string.IsNullOrEmpty(forAppId))
             depotConfigStore.VerifyAppsStateFlag(uint.Parse(forAppId));
 
+        // Make sure steam compatibility is enabled for all titles
+        var globalConfig = new GlobalConfig(GlobalConfig.DefaultPath());
+        globalConfig.SetProton9CompatForApp(0, 75);
+        globalConfig.Save();
+
         var arguments = new List<string>(ARGUMENTS);
 
         if (!offlineMode)


### PR DESCRIPTION
The overall goal of this PR is the following:
- Make resuming downloads faster since right now we need to re-verify all chunks when resuming
- Download shared depots to the shared folder instead of the game folder

Changes:
- replace all KeyValue.Save with KeyValue.SaveToFileWithAtomicRename to avoid partial file writes if program is killed
- on download, look for install script files being downloaded and set them in correspondent app manifest
- correctly differentiate between dlc and shared depot
- during download, create temporary manifest files in .DepotDownloader/status to track chunk downloads so we can resume downloads faster
- download will now execute in 2 steps, Preallocation/Verification then Download
- set proton compatibility setting for appid 0 so it applies to all apps
- read post install scripts from appmanifest instead of directory
- resolve issues with SteamSession errors due to multi threading access of dictionaries
- during downloaded app verification, also compare app version
- throw error during pre launch hook if app is not installed
- if launching in online mode during pre launch hook, throw error if app requires update