### PR TITLE
Fix: Os/Platform Related Fixes

### DIFF
--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -1114,7 +1114,7 @@ public class DepotConfigStore
         currentAccountId = accountId;
     }
 
-    public List<uint> GetDisabledDlcDepotIds(uint appId)
+    public List<uint> GetDisabledDlcIds(uint appId)
     {
         if (!manifestMap.TryGetValue(appId, out var data)) return [];
         return data[KEY_USER_CONFIG]?[KEY_CONFIG_DISABLED_DLC]?.AsString()?.Split(",").Select(uint.Parse).ToList() ?? [];

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -319,7 +319,7 @@ public class DepotConfigStore
         }
     }
 
-    public void VerifyAppsOsConfigAsync(uint accountId)
+    public void VerifyAppsOsConfig(uint accountId)
     {
         var globalConfig = new GlobalConfig(GlobalConfig.DefaultPath());
         var userCompatConfig = accountId == 0 ? null : new UserCompatConfig(UserCompatConfig.DefaultPath(accountId));

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -1154,7 +1154,12 @@ public class DepotConfigStore
             var oslist = depotsSection[depotId.ToString()]["config"]["oslist"]?.AsString();
 
             if (!string.IsNullOrEmpty(oslist))
-                return oslist.Split(",").FirstOrDefault();
+            {
+                var oslistSplit = oslist.Split(",");
+
+                if (oslistSplit.Count() == 1)
+                    return oslistSplit.FirstOrDefault();
+            }
         }
 
         return ContentDownloader.GetSteamOS();

--- a/SteamBus.App/src/Steam.Config/GlobalConfig.cs
+++ b/SteamBus.App/src/Steam.Config/GlobalConfig.cs
@@ -135,6 +135,23 @@ public class GlobalConfig
         }
     }
 
+    // Removes compat tool for an app id
+    public void RemoveCompatForApp(uint appId)
+    {
+        EnsureRootKeysExist();
+
+        var appIdStr = appId.ToString();
+        var child = this.data![KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr];
+        if (child != KeyValue.Invalid)
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING].Children.Remove(child);
+    }
+
+    // Get compat config for an app id
+    public string GetCompatForApp(uint appId)
+    {
+        return this.data?[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appId.ToString()][KEY_COMPAT_TOOL_MAPPING_NAME].AsString() ?? "";
+    }
+
     void EnsureRootKeysExist()
     {
         // Ensure all keys exist

--- a/SteamBus.App/src/Steam.Config/UserCompatConfig.cs
+++ b/SteamBus.App/src/Steam.Config/UserCompatConfig.cs
@@ -84,6 +84,12 @@ public class UserCompatConfig
         if (data == null)
             Reload();
 
+        if (destPlatform == srcPlatform)
+        {
+            data!.Children.Remove(data[appId.ToString()]);
+            return;
+        }
+
         var config = new KeyValue(appId.ToString());
         config["dest"] = new KeyValue("dest", destPlatform);
         config["src"] = new KeyValue("src", srcPlatform);

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -917,6 +917,10 @@ public class ContentDownloader
       {
         downloadCounter.sizeDownloaded += oldDepot.ManifestSize;
         downloadCounter.completeDownloadSize += oldDepot.ManifestSize;
+
+        if (depot.IsSharedDepot)
+          depotConfigStore.SetSharedDepot(appId, depot.AppId, depot.DepotId);
+
         continue;
       }
 

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -501,7 +501,7 @@ public class ContentDownloader
     var depotIdsFound = new List<uint>();
     var depotIdsExpected = requiredDepots.Select(x => x.DepotId).ToList();
     var depots = session.GetSteam3AppSection(appId, EAppInfoSection.Depots);
-    var disabledDlcDepotIds = depotConfigStore.GetDisabledDlcDepotIds(appId);
+    var disabledDlcIds = depotConfigStore.GetDisabledDlcIds(appId);
 
     if (depots == null)
       throw DbusExceptionHelper.ThrowContentNotFound();
@@ -578,9 +578,6 @@ public class ContentDownloader
           }
         }
 
-        if (disabledDlcDepotIds.Contains(id))
-          continue;
-
         depotIdsFound.Add(id);
 
         if (!hasSpecificDepots)
@@ -595,8 +592,12 @@ public class ContentDownloader
           else
           {
             var dlcAppId = depotSection["dlcappid"]?.AsUnsignedInteger() ?? 0;
-            var isDlc = dlcAppId != 0;
-            requiredDepots.Add(new RequiredDepot(id, INVALID_MANIFEST_ID, depotFromApp == 0 ? appId : depotFromApp, false, isDlc));
+
+            if (!disabledDlcIds.Contains(dlcAppId))
+            {
+              var isDlc = dlcAppId != 0;
+              requiredDepots.Add(new RequiredDepot(id, INVALID_MANIFEST_ID, depotFromApp == 0 ? appId : depotFromApp, false, isDlc));
+            }
           }
         }
       }
@@ -618,14 +619,17 @@ public class ContentDownloader
     }
 
     // Handle DLCs
-    var dlcDepotIds = session.GetExtendedDLCs(appId);
-    if (dlcDepotIds.Count() > 0)
+    var dlcAppIds = session.GetExtendedDLCs(appId);
+    if (dlcAppIds.Count() > 0)
     {
-      dlcDepotIds = dlcDepotIds.Except(disabledDlcDepotIds).ToList();
+      foreach (var dlcAppId in dlcAppIds)
+      {
+        var dlcRequiredDepots = await GetAppRequiredDepots(dlcAppId, options, log);
 
-      foreach (var dlcDepotId in dlcDepotIds)
-        if (dlcDepotId != 0 && !requiredDepots.Any((d) => d.DepotId == dlcDepotId))
-          requiredDepots.Add(new RequiredDepot(dlcDepotId, INVALID_MANIFEST_ID, dlcDepotId, false, true));
+        foreach (var dlcDepot in dlcRequiredDepots)
+          if (!disabledDlcIds.Contains(dlcDepot.DepotAppId) && !requiredDepots.Any((d) => d.DepotId == dlcDepot.DepotId))
+            requiredDepots.Add(new RequiredDepot(dlcDepot.DepotId, dlcDepot.ManifestId, dlcDepot.DepotAppId, false, true));
+      }
     }
 
     List<RequiredDepot> validDepotManifestIds = [];
@@ -639,13 +643,12 @@ public class ContentDownloader
         continue;
       }
 
-      var isDlc = dlcDepotIds.Contains(requiredDepot.DepotId);
-      var depotFromAppId = isDlc ? requiredDepot.DepotId : appId;
+      var depotFromAppId = requiredDepot.IsDlc ? requiredDepot.DepotAppId : appId;
 
       var manifestId = await GetSteam3DepotManifest(requiredDepot.DepotId, depotFromAppId, options.Branch);
 
       // If is dlc and manifest was not found in dlc app info, find in parent app
-      if (isDlc && manifestId == INVALID_MANIFEST_ID)
+      if (requiredDepot.IsDlc && manifestId == INVALID_MANIFEST_ID)
       {
         manifestId = await GetSteam3DepotManifest(requiredDepot.DepotId, appId, options.Branch);
       }

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -326,14 +326,20 @@ public class ContentDownloader
 
     try
     {
-      if (string.IsNullOrEmpty(options.Os))
+      var installedApp = depotConfigStore.GetInstalledAppInfo(appId);
+
+      if (installedApp != null)
       {
-        var installedApp = depotConfigStore.GetInstalledAppInfo(appId);
-        options.Os = installedApp?.Info.Os ?? "";
+        options.InstallDirectory = installedApp.Value.Info.InstalledPath;
+
+        if (string.IsNullOrEmpty(options.Os))
+          options.Os = installedApp?.Info.Os ?? "";
       }
 
       var currentOs = GetSteamOS();
       var os = options.Os ?? currentOs;
+
+      Console.WriteLine($"Installing app to {options.InstallDirectory} with os: {os}");
 
       // Set the platform override so steam client won't detect an update when analyzing the game
       var userCompatConfig = new UserCompatConfig(UserCompatConfig.DefaultPath(this.session.SteamUser!.SteamID!.AccountID));

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -43,16 +43,18 @@ public class SteamClientApp
     private TaskCompletionSource? endingTask;
 
     private DisplayManager displayManager;
-    private DepotConfigStore depotConfigStore;
+    private DepotConfigStore appsDepotConfigStore;
+    private DepotConfigStore toolsDepotConfigStore;
 
     private SteamuiLogs steamuiLogs;
 
     private string forAppId = "";
 
-    public SteamClientApp(DisplayManager displayManager, DepotConfigStore depotConfigStore)
+    public SteamClientApp(DisplayManager displayManager, DepotConfigStore appsDepotConfigStore, DepotConfigStore toolsDepotConfigStore)
     {
         this.displayManager = displayManager;
-        this.depotConfigStore = depotConfigStore;
+        this.appsDepotConfigStore = appsDepotConfigStore;
+        this.toolsDepotConfigStore = toolsDepotConfigStore;
         this.steamuiLogs = new SteamuiLogs(SteamuiLogs.DefaultPath());
     }
 
@@ -89,9 +91,9 @@ public class SteamClientApp
         steamuiLogs.Delete();
 
         // Verify all installed apps have correct config so steam client does not set them to update pending
-        depotConfigStore.VerifyAppsOsConfig(accountId);
+        appsDepotConfigStore.VerifyAppsOsConfigAsync(accountId);
         if (!string.IsNullOrEmpty(forAppId))
-            depotConfigStore.VerifyAppsStateFlag(uint.Parse(forAppId));
+            appsDepotConfigStore.VerifyAppsStateFlag(uint.Parse(forAppId));
 
         // Make sure steam compatibility is enabled for all titles
         var globalConfig = new GlobalConfig(GlobalConfig.DefaultPath());
@@ -194,8 +196,8 @@ public class SteamClientApp
             // If an update was happening, mark it as complete
             if (updating)
             {
-                depotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
-                depotConfigStore.Save(STEAM_CLIENT_APP_ID);
+                toolsDepotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
+                toolsDepotConfigStore.Save(STEAM_CLIENT_APP_ID);
 
                 Console.WriteLine("Steam client update has completed");
                 updating = false;
@@ -247,6 +249,8 @@ public class SteamClientApp
                     }
                     else
                     {
+                        await Task.Delay(1000);
+
                         readyTask.TrySetResult();
                         readyTask = null;
                         Console.WriteLine("Steam client is ready");
@@ -306,10 +310,10 @@ public class SteamClientApp
             {
                 var manifestDir = GetManifestDirectory();
                 Directory.CreateDirectory(manifestDir);
-                depotConfigStore.EnsureEntryExists(manifestDir, STEAM_CLIENT_APP_ID, "Steam");
-                depotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "english", "linux");
-                depotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
-                depotConfigStore.Save(STEAM_CLIENT_APP_ID);
+                toolsDepotConfigStore.EnsureEntryExists(manifestDir, STEAM_CLIENT_APP_ID, "Steam");
+                toolsDepotConfigStore.SetNewVersion(STEAM_CLIENT_APP_ID, uint.Parse(updatingToVersion), "public", "english", "linux");
+                toolsDepotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, null);
+                toolsDepotConfigStore.Save(STEAM_CLIENT_APP_ID);
 
                 Console.WriteLine("Steam client update has started");
                 updating = true;
@@ -317,10 +321,10 @@ public class SteamClientApp
             }
             else
             {
-                depotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, DownloadStage.Downloading);
-                depotConfigStore.SetCurrentSize(STEAM_CLIENT_APP_ID, currentBytesValue);
-                depotConfigStore.SetTotalSize(STEAM_CLIENT_APP_ID, totalBytesValue);
-                depotConfigStore.Save(STEAM_CLIENT_APP_ID);
+                toolsDepotConfigStore.SetDownloadStage(STEAM_CLIENT_APP_ID, DownloadStage.Downloading);
+                toolsDepotConfigStore.SetCurrentSize(STEAM_CLIENT_APP_ID, currentBytesValue);
+                toolsDepotConfigStore.SetTotalSize(STEAM_CLIENT_APP_ID, totalBytesValue);
+                toolsDepotConfigStore.Save(STEAM_CLIENT_APP_ID);
 
                 Console.WriteLine($"Current steam download at {progress:F2}% ({currentBytesValue} / {totalBytesValue} bytes)");
 
@@ -351,7 +355,7 @@ public class SteamClientApp
     {
         if (version == null || totalBytes == null)
         {
-            var info = depotConfigStore.GetInstalledAppInfo(STEAM_CLIENT_APP_ID)?.Info;
+            var info = toolsDepotConfigStore.GetInstalledAppInfo(STEAM_CLIENT_APP_ID)?.Info;
             version ??= info?.Version ?? "0";
             totalBytes ??= info?.TotalDownloadSize ?? 0;
 
@@ -370,7 +374,7 @@ public class SteamClientApp
     private void OnExited(object? sender, EventArgs e)
     {
         // Reload depot config store in case steam client changed the manifests
-        _ = depotConfigStore.Reload();
+        _ = toolsDepotConfigStore.Reload();
 
         Console.WriteLine($"Steam client exited with code {process?.ExitCode}");
         process = null;

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -91,7 +91,7 @@ public class SteamClientApp
         steamuiLogs.Delete();
 
         // Verify all installed apps have correct config so steam client does not set them to update pending
-        appsDepotConfigStore.VerifyAppsOsConfigAsync(accountId);
+        appsDepotConfigStore.VerifyAppsOsConfig(accountId);
         if (!string.IsNullOrEmpty(forAppId))
             appsDepotConfigStore.VerifyAppsStateFlag(uint.Parse(forAppId));
 
@@ -249,7 +249,7 @@ public class SteamClientApp
                     }
                     else
                     {
-                        await Task.Delay(1000);
+                        await Task.Delay(2000);
 
                         readyTask.TrySetResult();
                         readyTask = null;

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -124,6 +124,7 @@ public class SteamSession
     this.steamApps = this.SteamClient.GetHandler<SteamApps>();
     this.steamFriends = this.SteamClient.GetHandler<SteamFriends>();
     this.steamCloudKit = this.SteamClient.GetHandler<SteamKit2.SteamCloud>();
+
     var steamUnifiedMessages = this.SteamClient.GetHandler<SteamUnifiedMessages>();
     if (steamUnifiedMessages == null)
     {

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -117,7 +117,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
   // Creates a new DBusSteamClient instance with the given DBus path
   public DBusSteamClient(ObjectPath path, DepotConfigStore depotConfigStore, DepotConfigStore dependenciesStore, DisplayManager displayManager, INetworkManager networkManager)
   {
-    steamClientApp = new SteamClientApp(displayManager, dependenciesStore);
+    steamClientApp = new SteamClientApp(displayManager, depotConfigStore, dependenciesStore);
 
     // DBus path to this Steam Client instance
     this.Path = path;


### PR DESCRIPTION
- fix in some cases wrong platform was identified for installed app in external drives
  - this was normalized to rely more on compat tool config to know which platform
- remove compat config for games that are installed as linux
- add small delay post steam client being ready before app launch to make sure steam sdk is initialized before game launches