### PR TITLE
fix: check for game ownership when getting required depots

### DIFF
--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -489,6 +489,9 @@ public class ContentDownloader
 
   public async Task<List<RequiredDepot>> GetAppRequiredDepots(uint appId, AppDownloadOptions options, bool forceRefreshDepots = true, bool log = true)
   {
+    if (!session.IsAppOwned(appId))
+      return [];
+
     await this.session.RequestAppInfo(appId);
 
     var os = options.Os ?? GetSteamOS();
@@ -596,6 +599,9 @@ public class ContentDownloader
             if (!disabledDlcIds.Contains(dlcAppId))
             {
               var isDlc = dlcAppId != 0;
+              if (isDlc && !session.IsAppOwned(dlcAppId))
+                continue;
+
               requiredDepots.Add(new RequiredDepot(id, INVALID_MANIFEST_ID, depotFromApp == 0 ? appId : depotFromApp, false, isDlc));
             }
           }

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -868,6 +868,7 @@ public class SteamSession
     }
   }
 
+  public bool IsAppOwned(uint appId) => ProviderItemMap.ContainsKey(appId);
 
   // Invoked on login to list the game/app licenses associated with the user.
   private async void OnLicenseList(SteamApps.LicenseListCallback licenseList)
@@ -1234,6 +1235,9 @@ public class SteamSession
 
   public async Task<bool> VerifyDownloadedApp(ContentDownloader downloader, InstallOptionsExtended installedApp)
   {
+    if (DBusSteamClient.fetchingSteamClientData != null) await DBusSteamClient.fetchingSteamClientData.Task;
+    if (isLoadingLibrary) await WaitForLibrary();
+
     try
     {
       var newestVersion = GetSteam3AppBuildNumber(installedApp.appId, installedApp.branch).ToString();


### PR DESCRIPTION
- this should fix the issue with some games being marked as update needed after restarting SteamBus
- also makes start of download faster for games with lots of dlcs since we dont fetch app info for all of them
