### PR TITLE
feat: add missing Copy Files field from installation scripts and fix registry field

### DIFF
--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -1098,6 +1098,17 @@ public class ContentDownloader
 
     Console.WriteLine("Total downloaded: {0} bytes ({1} bytes uncompressed) from {2} depots",
         downloadCounter.totalBytesCompressed, downloadCounter.totalBytesUncompressed, depots.Count);
+
+    // Mark app download as finished in case it didnt even download anything
+    if (downloadCounter.totalBytesCompressed == 0)
+      this.OnInstallProgressed?.Invoke(new InstallProgressedDescription
+      {
+        AppId = appId.ToString(),
+        Stage = (uint)DownloadStage.Verifying,
+        DownloadedBytes = 0,
+        TotalDownloadSize = 0,
+        Progress = 100,
+      });
   }
 
 


### PR DESCRIPTION
- parse missing Copy Files field from install scripts
- fix language declared in registries when not supposed to
- remove _WOW64_* string from registry group name
- send final download status after download if nothing was downloaded (ensure last stage was not Preallocating)