### PR TITLE
fix: fixes regarding steam client launching post login

### DIFF
--- a/SteamBus.App/src/Steam.Cloud/CloudUtils.cs
+++ b/SteamBus.App/src/Steam.Cloud/CloudUtils.cs
@@ -216,8 +216,12 @@ public class CloudUtils
                 {
                     var offset = request.ShouldSerializeblock_offset() ? (long)request.block_offset : 0;
                     var length = request.ShouldSerializeblock_length() ? (int)request.block_length : (int)fileContents.Length;
-                    fileContents.Seek(offset, SeekOrigin.Begin);
-                    httpRequest.Content = new StreamContent(fileContents, length);
+
+                    if (length != 0)
+                    {
+                        fileContents.Seek(offset, SeekOrigin.Begin);
+                        httpRequest.Content = new StreamContent(fileContents, length);
+                    }
                 }
 
                 foreach (var header in request.request_headers)

--- a/SteamBus.App/src/Steam.Config/GlobalConfig.cs
+++ b/SteamBus.App/src/Steam.Config/GlobalConfig.cs
@@ -35,6 +35,7 @@ public class GlobalConfig
     public const string KEY_STEAM = "Steam";
     public const string KEY_ACCOUNTS = "Accounts";
     public const string KEY_STEAM_ID = "SteamID";
+    public const string KEY_CONNECT_CACHE = "ConnectCache";
     public const string KEY_COMPAT_TOOL_MAPPING = "CompatToolMapping";
     public const string KEY_COMPAT_TOOL_MAPPING_NAME = "name";
     public const string KEY_COMPAT_TOOL_MAPPING_CONFIG = "config";
@@ -133,6 +134,25 @@ public class GlobalConfig
             this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_CONFIG] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_CONFIG, "");
             this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_COMPAT_TOOL_MAPPING][appIdStr][KEY_COMPAT_TOOL_MAPPING_PRIORITY] = new KeyValue(KEY_COMPAT_TOOL_MAPPING_PRIORITY, priority.ToString());
         }
+    }
+
+    // Sets ConnectCache for steam client to re-use session
+    public void SetConnectCache(string username, string refreshToken)
+    {
+        EnsureRootKeysExist();
+
+        // The ConnectCache key is the hex-encoded CRC32 hash of the username with "1" added to the end.
+        string key = SteamConfig.GetUsernameCrcString(username);
+
+        // Encrypt the token into a hex-encoded string
+        string value = SteamConfig.EncryptTokenForUser(username, refreshToken);
+
+        if (String.IsNullOrEmpty(this.data![KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_CONNECT_CACHE].Name))
+        {
+            this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_CONNECT_CACHE] = new KeyValue(KEY_CONNECT_CACHE);
+        }
+
+        this.data[KEY_SOFTWARE][KEY_VALVE][KEY_STEAM][KEY_CONNECT_CACHE][key] = new KeyValue(key, value);
     }
 
     // Removes compat tool for an app id

--- a/SteamBus.App/src/Steam.Config/InstallScript.cs
+++ b/SteamBus.App/src/Steam.Config/InstallScript.cs
@@ -209,21 +209,13 @@ public class InstallScript
         var strings = new List<PostInstallRegistryValue>();
         var dwords = new List<PostInstallRegistryValue>();
 
-        var arch = ContentDownloader.GetSteamArch();
-
         foreach (var group in registry.Children)
         {
             if (string.IsNullOrEmpty(group.Name))
                 continue;
 
-            var groupName = group.Name;
-
-            if (groupName.Contains("_WOW64_"))
-            {
-                var wow64Text = $"_WOW64_{arch}";
-                if (!groupName.Contains(wow64Text)) continue;
-                groupName = string.Join("", groupName.Split(wow64Text));
-            }
+            const string pattern = @"_WOW\d+_\d+";
+            var groupName = Regex.Replace(group.Name, pattern, string.Empty);
 
             foreach (var type in group.Children)
             {

--- a/SteamBus.App/src/Steam.Config/SteamuiLogs.cs
+++ b/SteamBus.App/src/Steam.Config/SteamuiLogs.cs
@@ -63,6 +63,7 @@ public class SteamuiLogs
                         }
 
                         if (line.Contains("WaitingForCredentials - Password is not set")
+                            || line.Contains("WaitingForCredentials - Already Logged In Elsewhere")
                             || line.Contains("WaitingForCredentials - Access Denied")
                             || line.Contains("WaitingForCredentials - Invalid Password")
                             || line.Contains("WaitingForCredentials - No Connection")

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -48,7 +48,10 @@ public class SteamClientApp
 
     private SteamuiLogs steamuiLogs;
 
-    private string forAppId = "";
+    public string forAppId = "";
+
+    // Used to keep track when last successful login was
+    public DateTime lastLoggedIn = DateTime.MinValue;
 
     public SteamClientApp(DisplayManager displayManager, DepotConfigStore appsDepotConfigStore, DepotConfigStore toolsDepotConfigStore)
     {
@@ -251,6 +254,7 @@ public class SteamClientApp
                     {
                         await Task.Delay(2000);
 
+                        lastLoggedIn = DateTime.UtcNow;
                         readyTask.TrySetResult();
                         readyTask = null;
                         Console.WriteLine("Steam client is ready");

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -746,16 +746,14 @@ public class SteamSession
       // Any operations outstanding need to be aborted
       bAborted = true;
     }
-    else if (connectionBackoff >= 4)
+    else if (connectionBackoff >= 7)
     {
       Console.WriteLine("Could not connect to Steam after 4 tries");
       Abort(false);
     }
     else if (!bAborted)
     {
-      // We don't want to back off in case of reconnection
-      if (!bExpectingDisconnectRemote)
-        connectionBackoff += 1;
+      connectionBackoff += 1;
 
       if (bConnecting)
       {
@@ -856,6 +854,7 @@ public class SteamSession
 
   public void SaveToken()
   {
+    Console.WriteLine("#### TEST");
     if (logonDetails?.Username != null && logonDetails?.AccessToken != null && SteamUser?.SteamID != null)
     {
       var localConfig = new LocalConfig(LocalConfig.DefaultPath());
@@ -864,6 +863,7 @@ public class SteamSession
 
       var globalConfig = new GlobalConfig(GlobalConfig.DefaultPath());
       globalConfig.SetSteamUser(logonDetails.Username, SteamUser.SteamID.ConvertToUInt64().ToString());
+      globalConfig.SetConnectCache(logonDetails.Username, logonDetails.AccessToken);
       globalConfig.Save();
     }
   }
@@ -1196,25 +1196,6 @@ public class SteamSession
       else
         Console.Error.WriteLine("Error parsing Sub out of access token");
     }
-  }
-
-  public void DeleteUserConfigOfflineTicket()
-  {
-    if (logonDetails.AccountID == 0) return;
-
-    var (config, path) = loginUsersConfig.GetUserConfig(logonDetails.AccountID.ToString());
-    var child = config.Children.Find((c) => c.Name == "Offline");
-    if (child != null) config.Children.Remove(child);
-
-    config.SaveToFileWithAtomicRename(path);
-  }
-
-  public bool IsUserConfigReady()
-  {
-    if (logonDetails.AccountID == 0) return false;
-
-    var (config, _) = loginUsersConfig.GetUserConfig(logonDetails.AccountID.ToString());
-    return !string.IsNullOrEmpty(config["Offline"]?["Ticket"]?.Value);
   }
 
   /// <summary>

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -854,7 +854,6 @@ public class SteamSession
 
   public void SaveToken()
   {
-    Console.WriteLine("#### TEST");
     if (logonDetails?.Username != null && logonDetails?.AccessToken != null && SteamUser?.SteamID != null)
     {
       var localConfig = new LocalConfig(LocalConfig.DefaultPath());

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -112,6 +112,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
   private bool isOnline = false;
 
   public static TaskCompletionSource? fetchingSteamClientData;
+  public static TaskCompletionSource? steamClientWaiting;
 
 
   // Creates a new DBusSteamClient instance with the given DBus path
@@ -225,6 +226,8 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
         OnUserPropsChanged?.Invoke(new PropertyChanges([], ["Avatar", "Username", "Identifier", "Status"]));
       }
     }
+    else
+      await LaunchSteamClientToSyncTokens(session.GetLogonDetails());
   }
 
   // Decrypt the given base64 encoded string using our private key
@@ -816,6 +819,17 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     {
       if (!wantsOfflineMode && session.playingBlocked) throw DbusExceptionHelper.ThrowPlayingBlocked();
 
+      // Return early in case steam client is already running and ready
+      if (steamClientWaiting != null)
+      {
+        if (steamClientApp.readyTask != null) await steamClientApp.readyTask.Task;
+        steamClientWaiting?.TrySetResult();
+        steamClientWaiting = null;
+        steamClientApp.forAppId = appIdString;
+        OnLaunchReady?.Invoke(appIdString);
+        return [];
+      }
+
       var logonDetails = session!.GetLogonDetails();
       await steamClientApp.Start(logonDetails.AccountID, appIdString, logonDetails.Username!, wantsOfflineMode);
     }
@@ -1284,58 +1298,75 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
 
     _ = Task.Run(async () =>
     {
-      if (loginDetails.Username == null || steamClientApp.running || !isOnline) return;
+      await Task.Delay(TimeSpan.FromSeconds(30));
+      await LaunchSteamClientToSyncTokens(loginDetails);
+    });
+  }
 
-      fetchingSteamClientData = new();
-      Console.WriteLine("Logging in with steam client to fetch latest data");
+  async Task LaunchSteamClientToSyncTokens(SteamUser.LogOnDetails loginDetails)
+  {
+    if (loginDetails.Username == null || steamClientApp.running || !isOnline) return;
+
+    if (DateTime.UtcNow - steamClientApp.lastLoggedIn < TimeSpan.FromHours(6))
+    {
+      Console.WriteLine("Skipping steam client sync: Task ran less than 6 hours ago.");
+      return;
+    }
+
+    fetchingSteamClientData = new();
+    Console.WriteLine("Logging in with steam client to fetch latest data");
+
+    try
+    {
+      await steamClientApp.Start(loginDetails.AccountID, "", loginDetails.Username, false);
+    }
+    catch (Exception exception)
+    {
+      Console.Error.WriteLine($"Failed starting steam client to fetch data post login, err:{exception}");
+    }
+    finally
+    {
+      try
+      {
+        if (steamClientApp.updateEndedTask != null) await steamClientApp.updateEndedTask.Task;
+      }
+      catch (Exception) { }
 
       try
       {
-        // Delete offline ticket so we can re-generated it and know when to quit the client
-        session?.DeleteUserConfigOfflineTicket();
-
-        await steamClientApp.Start(loginDetails.AccountID, "", loginDetails.Username, false);
+        if (steamClientApp.readyTask != null) await steamClientApp.readyTask.Task;
       }
-      catch (Exception exception)
+      catch (Exception) { }
+
+      // Mark this process as finished
+      fetchingSteamClientData?.TrySetResult();
+      fetchingSteamClientData = null;
+
+      // If game launch doesn't happen within 1 minute, close steam client
+      steamClientWaiting = new();
+      await AsyncUtils.WaitForConditionAsync(() => steamClientWaiting == null || !steamClientApp.running, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(1));
+
+      if (steamClientWaiting != null)
       {
-        Console.Error.WriteLine($"Failed starting steam client to fetch data post login, err:{exception}");
-      }
-      finally
-      {
         try
         {
-          if (steamClientApp.updateEndedTask != null) await steamClientApp.updateEndedTask.Task;
-        }
-        catch (Exception) { }
-
-        try
-        {
-          if (steamClientApp.readyTask != null) await steamClientApp.readyTask.Task;
-        }
-        catch (Exception) { }
-
-
-        try
-        {
-          // Wait until offline field is populated with updated data
-          var delay = TimeSpan.FromMilliseconds(200);
-          var timeout = TimeSpan.FromSeconds(20);
-          var success = await AsyncUtils.WaitForConditionAsync(() => session?.IsUserConfigReady() ?? false, delay, timeout);
-
-          if (!success) Console.Error.WriteLine($"Steam has not generated user files...");
-
-          await steamClientApp.ShutdownSteamWithTimeoutAsync(TimeSpan.FromSeconds(10));
           Console.WriteLine("Shut down steam client after fetching data");
+          await steamClientApp.ShutdownSteamWithTimeoutAsync(TimeSpan.FromSeconds(20));
         }
         catch (Exception err)
         {
           Console.Error.WriteLine($"Error waiting and shutting down steam client after launching it to fetch configs: {err}");
         }
+        finally
+        {
+          steamClientWaiting?.TrySetResult();
+          steamClientWaiting = null;
+        }
       }
+    }
 
-      fetchingSteamClientData?.TrySetResult();
-      fetchingSteamClientData = null;
-    });
+    fetchingSteamClientData?.TrySetResult();
+    fetchingSteamClientData = null;
   }
 
   void OnLoggedOff(SteamUser.LoggedOffCallback callback)


### PR DESCRIPTION
- wait 30 seconds post login to launch steam client (avoids Already Logged In Elsewhere error)
- launch steam client when coming back online if it has been 6 hours since last launch at least
- reuse first launched steam client instance during app launch if it is still open
- no longer delete steam offline token to avoid issues in case client fails to launch
- revert connection backoff changes to error out after 7 times even TryAnotherCM error keeping appearing
- fix install script parsing to return all WOW registry values
- set ConnectCache on global config as well post login (seems to be used in some case to keep same connection as steamkit)