### PR TITLE
feat: listen to running providers in playserve and only run steam client if there isnt any other provider running

### DIFF
--- a/SteamBus.App/src/Playserve/Manager.cs
+++ b/SteamBus.App/src/Playserve/Manager.cs
@@ -26,9 +26,12 @@ public interface IPluginManager : IDBusObject
 
     // Properties
     Task<string> GetVersionAsync();
+    Task<string> GetRunningAppIdAsync();
+    Task<string> GetRunningProviderAsync();
 
     // Signals
     Task<IDisposable> WatchPluginRegisteredAsync(Action<(string pluginName, uint pluginId)> handler);
     Task<IDisposable> WatchOnDriveAddedAsync(Action<DriveInfo> handler);
     Task<IDisposable> WatchOnDriveRemovedAsync(Action<string> handler);
+    Task<IDisposable> WatchPropertiesAsync(Action<PropertyChanges> handler, Action<Exception>? exception = null);
 }

--- a/SteamBus.App/src/SteamBus.cs
+++ b/SteamBus.App/src/SteamBus.cs
@@ -91,6 +91,25 @@ class SteamBus
         client.EmitInstalledAppsUpdated();
       });
 
+      await pluginManager.WatchPropertiesAsync((changes) =>
+      {
+        try
+        {
+          foreach (var (key, value) in changes.Changed)
+          {
+            if (key == "RunningProvider" && value != null)
+            {
+              var valueStr = value as string;
+              client.SetSteamClientEnabled(string.IsNullOrEmpty(valueStr) || valueStr.ToLower() == "steam");
+            }
+          }
+        }
+        catch (Exception exception)
+        {
+          Console.Error.WriteLine($"Error occurred when listening to plugin manager property changes, err:{exception}");
+        }
+      });
+
       var drives = await pluginManager.GetDrivesAsync();
       var libraryConfig = await LibraryFoldersConfig.CreateAsync();
       foreach (var drive in drives)


### PR DESCRIPTION
Basically this makes it so if there is another app from a different provider running in playserve, steam client won't open as it might affect the running game's performance