### PR TITLE
fix(GRID-1472): exclude steam_autocloud from initial file map

### DIFF
--- a/SteamBus.App/src/Steam.Cloud/CloudUtils.cs
+++ b/SteamBus.App/src/Steam.Cloud/CloudUtils.cs
@@ -50,9 +50,6 @@ public class CloudUtils
         }
         foreach (var file in localFiles)
         {
-            if (file.Key.Contains("steam_autocloud.vdf"))
-                continue;
-
             if (!remoteFiles.TryGetValue(file.Key, out var remoteFile))
                 res.changedLocal.Add(file.Value);
             else if (remoteFile.Time < file.Value.UpdateTime)

--- a/SteamBus.App/src/Steam.Cloud/SteamCloud.cs
+++ b/SteamBus.App/src/Steam.Cloud/SteamCloud.cs
@@ -216,6 +216,9 @@ public class SteamCloud(SteamUnifiedMessages steamUnifiedMessages)
       string[] files = Directory.GetFiles(mapRoot.path, mapRoot.pattern, new EnumerationOptions() { RecurseSubdirectories = mapRoot.recursive });
       foreach (var file in files)
       {
+        if (Path.GetFileName(file).ToLower() == "steam_autocloud.vdf") {
+          continue;
+        }
         var newFile = new LocalFile(file, file[mapRoot.path.Length..], mapRoot.alias, syncPlatform);
         results.Add(newFile.GetRemotePath().ToLower(), newFile);
       }


### PR DESCRIPTION
This should fix an issue where in case of empty cloud it would show a conflict dialog with remote updated at 0 unix time.