### PR TITLE
Fix: Misc fixes

### DIFF
--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -95,7 +95,7 @@ public class SteamSession
   public uint playingAppID { get; private set; }
   public bool playingBlocked { get; private set; }
 
-  private bool isOnline;
+  public bool isOnline;
 
   public SteamSession(SteamUser.LogOnDetails details, DepotConfigStore depotConfigStore, string? steamGuardData = null, IAuthenticator? authenticator = null)
   {

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -962,6 +962,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     // Create a new Steam session using the given login details and the DBus interface
     // as an authenticator implementation.
     var session = new SteamSession(login, depotConfigStore, steamGuardData, this);
+    session.isOnline = isOnline;
     session.OnLibraryUpdated = OnLibraryUpdated;
     session.OnAppNewVersionFound = OnAppNewVersionFound;
     session.InstalledAppsUpdated = InstalledAppsUpdated;


### PR DESCRIPTION
- throttle download progress dbus events
- fix initial online status of steam session
- fix infinite loop on chunk download cancel

The story with this one is that I was chasing an issue where pausing current download and starting next was freezing everything, and I believe the progress messages were being sent way too often and caused some dbus messages/calls to be lost