### PR TITLE
fix(RPM): add aarch64 build

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -21,17 +21,19 @@ plugins:
     - replacements:
         - files:
             - SteamBus.App/SteamBus.csproj
-          from: '^<Version>.*</Version>$'
-          to: '<Version>${nextRelease.version}</Version>'
+          from: "^<Version>.*</Version>$"
+          to: "<Version>${nextRelease.version}</Version>"
         - files:
             - SteamBus.App/steam-bus.spec
-          from: '^Version: .*$'
-          to: 'Version: ${nextRelease.version}'
+          from: "^Version: .*$"
+          to: "Version: ${nextRelease.version}"
 
   # Execute commands to build the project
   - - "@semantic-release/exec"
     - shell: true
-      prepareCmd: "make in-docker TARGET='build-release rpm'"
+      prepareCmd: |
+        make in-docker TARGET='tar rpm'
+        make in-docker TARGET='tar rpm' ARCH="aarch64"
       publishCmd: "echo '${nextRelease.version}' > .version.txt"
 
   # Commit the following changes to git after other plugins have run
@@ -45,3 +47,4 @@ plugins:
     - assets:
         - path: SteamBus-*.rpm
         - path: SteamBus-*.tar.gz
+

--- a/SteamBus.App/steam-bus.spec
+++ b/SteamBus.App/steam-bus.spec
@@ -4,7 +4,6 @@ Release: 1%{?dist}
 Summary: SteamBus app used to interface with Steam Services
 License: GPLv2
 URL: https://github.com/playtron-os/steam-bus
-BuildArch: x86_64
 
 Requires: dotnet-sdk-8.0
 


### PR DESCRIPTION
This change adds the arm64 build of SteamBus to the Makefile and release CI.

It also includes a separate `tar` Makefile target to build the tar archive instead of including it as part of the `rpm` target and sets the appropriate target dependencies to automatically build the project if `make rpm` or `make tar` are ran.