### PR TITLE
fix: catch exception when reloading apps

### DIFF
--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -200,20 +200,34 @@ public class DepotConfigStore
         }
     }
 
-    public async Task ReloadApps(string dir)
+    public async Task ReloadApps(string dir, bool isRecursing = false)
     {
         var commonDir = Path.Join(dir, "common");
         if (!Directory.Exists(dir) || !Directory.Exists(commonDir))
             return;
 
-        var manifestPaths = Directory.EnumerateFiles(dir);
-
-        foreach (var manifestPath in manifestPaths ?? [])
+        try
         {
-            if (!manifestPath.EndsWith(".acf") || manifestPath.Contains(".extra.acf"))
-                continue;
+            var manifestPaths = Directory.EnumerateFiles(dir);
 
-            await ImportApp(manifestPath);
+            foreach (var manifestPath in manifestPaths ?? [])
+            {
+                if (!manifestPath.EndsWith(".acf") || manifestPath.Contains(".extra.acf"))
+                    continue;
+
+                await ImportApp(manifestPath);
+            }
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"Exception when importing apps from dir:{dir}, err:{exception}");
+
+            if (!isRecursing)
+            {
+                Console.WriteLine($"Attempting to reload apps again for dir:{dir}");
+                await ReloadApps(dir, true);
+                return;
+            }
         }
 
         Console.WriteLine($"Depot config store loaded {manifestPathMap.Count} installed apps");

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -208,7 +208,7 @@ public class DepotConfigStore
 
         try
         {
-            var manifestPaths = Directory.EnumerateFiles(dir);
+            var manifestPaths = Directory.EnumerateFiles(dir).ToList();
 
             foreach (var manifestPath in manifestPaths ?? [])
             {


### PR DESCRIPTION
This fixes this exception crashing the whole plugin:

```
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
--- End of stack trace from previous location ---
   at SteamBus.SteamBus.<>c__DisplayClass0_0.<<Main>b__1>d.MoveNext() in /src/SteamBus.App/src/SteamBus.cs:line 90
   at DepotConfigStore.Reload() in /src/SteamBus.App/src/Steam.Config/DepotConfigStore.cs:line 199
   at DepotConfigStore.ReloadApps(String dir) in /src/SteamBus.App/src/Steam.Config/DepotConfigStore.cs:line 211
   at System.IO.Enumeration.FileSystemEnumerator`1.MoveNext()
Unhandled exception. System.IO.IOException: Input/output error : '/run/media/mmcblk0p1.ext4/SteamLibrary/steamapps'
```