### PR TITLE
feat: scale max downloads with 50% cpu, while always being at least 4

### DIFF
--- a/SteamBus.App/src/Steam.Content/DownloadConfig.cs
+++ b/SteamBus.App/src/Steam.Content/DownloadConfig.cs
@@ -38,8 +38,9 @@ public class AppDownloadOptions
 
   // maximum number of content servers to use. (default: 20).
   public int MaxServers = 20;
-  // maximum number of chunks to download concurrently. (default: 8).
-  public int MaxDownloads = 8;
+  // maximum number of chunks to download concurrently.
+  // by default 50% of available cores, its always at least 4
+  public int MaxDownloads = Math.Max((int)Math.Round(Environment.ProcessorCount * 0.5), 4);
 
   public static async Task<AppDownloadOptions> CreateAsync(string installFolderName)
   {


### PR DESCRIPTION
this should give us some head room for other processes. 8 was quite aggressive especially on a Steam Deck, which has 4 cores and 8 threads