### PR TITLE
fix: fix pre launch hook failing if steam client already running and logged in and empty 2fa code aborting auth session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 IMAGE_NAME ?= playtron/steambus-builder
 IMAGE_TAG ?= latest
 ARCH ?= $(shell uname -m)
-DISTRO ?= fc41
+DISTRO ?= fc42
 ALL_CS := $(shell find SteamBus.App/src -name '*.cs')
 ALL_CSPROJ := $(shell find SteamBus.App -name '*.csproj')
 

--- a/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
+++ b/SteamBus.App/src/Steam.Config/LibraryFoldersConfig.cs
@@ -133,6 +133,8 @@ public class LibraryFoldersConfig
     /// <param name="mountPoint"></param>
     public void AddDiskEntry(string mountPoint)
     {
+        if (mountPoint.StartsWith("/etc")) return;
+
         string installPath;
         bool isMainDisk = Disk.IsMountPointMainDisk(mountPoint);
         if (isMainDisk)

--- a/SteamBus.App/src/Steam.Session/SteamClientApp.cs
+++ b/SteamBus.App/src/Steam.Session/SteamClientApp.cs
@@ -32,6 +32,7 @@ public class SteamClientApp
     public bool running { get; private set; }
     public bool updating { get; private set; }
     public bool loginFailed { get; private set; }
+    public bool isLoggedIn { get; private set; }
     private bool isReady;
     private string updatingToVersion = "0";
     private Process? process;
@@ -91,6 +92,7 @@ public class SteamClientApp
         isReady = false;
         loginFailed = false;
         readyTask = new();
+        isLoggedIn = false;
         steamuiLogs.Delete();
 
         // Verify all installed apps have correct config so steam client does not set them to update pending
@@ -188,6 +190,7 @@ public class SteamClientApp
             running = true;
             isReady = false;
             loginFailed = false;
+            isLoggedIn = false;
 
             if (startingTask == null) startingTask = new();
             if (readyTask == null) readyTask = new();
@@ -255,6 +258,7 @@ public class SteamClientApp
                         await Task.Delay(2000);
 
                         lastLoggedIn = DateTime.UtcNow;
+                        isLoggedIn = true;
                         readyTask.TrySetResult();
                         readyTask = null;
                         Console.WriteLine("Steam client is ready");

--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -795,7 +795,7 @@ public class SteamSession
       // Any operations outstanding need to be aborted
       bAborted = true;
     }
-    else if (connectionBackoff >= 7)
+    else if (connectionBackoff >= 12)
     {
       Console.WriteLine("Could not connect to Steam after 7 tries");
       Abort(false);
@@ -803,7 +803,9 @@ public class SteamSession
     }
     else if (!bAborted)
     {
-      connectionBackoff += 1;
+      // Only increment connection backoff if this is not a connection recovery
+      if (!bIsConnectionRecovery)
+        connectionBackoff += 1;
 
       if (isOnline)
       {

--- a/SteamBus.App/steam-bus.spec
+++ b/SteamBus.App/steam-bus.spec
@@ -1,5 +1,5 @@
 Name: SteamBus
-Version: 1.20.0
+Version: 1.20.2
 Release: 1%{?dist}
 Summary: SteamBus app used to interface with Steam Services
 License: GPLv2


### PR DESCRIPTION
- For the first issue, when SteamBus starts, 30 seconds later it also launches the steam client to auto refresh its session and data as well as update if needed. In case the steam client was already running and the user tries to use the PreLaunch hook (launching a game), then we'd run into a case where it didn't detect properly it was already running in the pre launch hook
- For the second issue, simply sending a blank 2fa code after beginning password auth would cause the flow to abort and the user wouldn't be able to try another 2fa code