### PR TITLE
feat: handle reconnecting status for provider linking and handle session disposing and token revoked better

### DIFF
--- a/SteamBus.App/src/Playtron.Plugin/LibraryProvider.cs
+++ b/SteamBus.App/src/Playtron.Plugin/LibraryProvider.cs
@@ -10,6 +10,14 @@ namespace Playtron.Plugin;
 /// typed tuples.
 using InstallOptionDescription = (string, string, string[]);
 
+public enum PluginProviderStatus
+{
+  Unauthorized = 0,
+  Requires2fa = 1,
+  Authorized = 2,
+  Reconnecting = 3,
+}
+
 [StructLayout(LayoutKind.Sequential)]
 public struct EulaEntry
 {

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -404,15 +404,14 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
 
   async Task<bool> EnsureConnected()
   {
-    if (this.session != null)
-      await this.session!.WaitLoggingInTask();
-
     // Ensure that a Steam session exists
     if (this.session is null)
     {
       Console.WriteLine("No active Steam session found");
       return false;
     }
+
+    await this.session!.WaitLoggingInTask();
 
     if (!this.session.IsLoggedOn)
     {
@@ -995,11 +994,10 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     session.OnAvatarUpdated = () => OnUserPropsChanged?.Invoke(new PropertyChanges([], ["Avatar"]));
 
     // Subscribe to client callbacks
-    session.Callbacks.Subscribe<SteamClient.ConnectedCallback>(OnConnected);
-    session.Callbacks.Subscribe<SteamClient.DisconnectedCallback>(OnDisconnected);
-    session.Callbacks.Subscribe<SteamUser.LoggedOnCallback>(OnLoggedOn);
-    session.Callbacks.Subscribe<SteamUser.LoggedOffCallback>(OnLoggedOff);
-    // session.Callbacks.Subscribe<SteamApps.LicenseListCallback>(OnLicenseList);
+    session.SubscribeCallback<SteamClient.ConnectedCallback>(OnConnected);
+    session.SubscribeCallback<SteamClient.DisconnectedCallback>(OnDisconnected);
+    session.SubscribeCallback<SteamUser.LoggedOnCallback>(OnLoggedOn);
+    session.SubscribeCallback<SteamUser.LoggedOffCallback>(OnLoggedOff);
 
     return session;
   }
@@ -1009,11 +1007,11 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
   {
     var isLoggedOn = this.session?.IsLoggedOn ?? false;
     var IsPendingLogin = this.session?.IsPendingLogin ?? false;
-    int status = isLoggedOn || IsPendingLogin ? 2 : 0;
+    int status = isLoggedOn || IsPendingLogin ? (int)PluginProviderStatus.Authorized : (int)PluginProviderStatus.Unauthorized;
     if (this.needsDeviceConfirmation || (this.tfaCodeTask != null))
-    {
-      status = 1;
-    }
+      status = (int)PluginProviderStatus.Requires2fa;
+    else if (this.session?.IsReconnecting ?? false)
+      status = (int)PluginProviderStatus.Reconnecting;
     return status;
   }
 
@@ -1049,7 +1047,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
 
     // Initiate the connection
     Console.WriteLine("Initializing Steam Client connection");
-    //this.steamClient.Connect();
+    this.session?.Dispose();
     this.session = InitSession(login, steamGuardData);
     await this.session.Login();
   }
@@ -1061,6 +1059,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     var login = new SteamUser.LogOnDetails();
     string? steamGuardData = null;
 
+    this.session?.Dispose();
     this.session = InitSession(login, steamGuardData);
     this.session.OnNewQrCode = OnQrCodeUpdated;
     Console.WriteLine("Connecting to Steam...");
@@ -1136,7 +1135,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
       return false;
     }
     needsDeviceConfirmation = false;
-    this.session?.Disconnect();
+    this.session?.Dispose();
     this.session = InitSession(login, steamGuardData);
 
     if (isOnline)
@@ -1159,7 +1158,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
     }
 
     Console.WriteLine("Session has expired, disconnecting");
-    this.session?.Disconnect();
+    this.session?.Dispose();
     this.session = null;
     OnUserPropsChanged?.Invoke(new PropertyChanges([], ["Avatar", "Username", "Identifier", "Status"]));
 


### PR DESCRIPTION
- Handle new "Reconnecting" state, emit it whenever reconnection is happening
- Extend IDisposable for SteamSession and handle disposing the callback listeners manually.. it seemed like they aren't automatically disposed
- Make sure `Task.Run(this.TickCallbacks);` only runs once
- Remove `Thread.Sleep(3000);` and use async task
- Properly send AuthError when rate limit exceeded exception happens during qr code login
- If error during QR code login happens, re-initialize QR code login session so the QR code remains valid