### PR TITLE
fix: exclude games from unsupported platforms

### DIFF
--- a/SteamBus.App/src/Steam.Session/SteamSession.cs
+++ b/SteamBus.App/src/Steam.Session/SteamSession.cs
@@ -1104,8 +1104,13 @@ public class SteamSession : IDisposable
             foreach (var entry in productInfo.Apps)
             {
               AppInfo[entry.Key] = entry.Value.KeyValues;
-              ProviderItemMap[entry.Key] = GetProviderItem(entry.Key.ToString(), entry.Value.KeyValues);
               appInfoCache.Save(entry.Key, entry.Value.KeyValues);
+
+              // Validate if we can install the game
+              var validOsList = entry.Value.KeyValues["extended"]?["validoslist"]?.AsString() ?? entry.Value.KeyValues["common"]?["oslist"]?.AsString();
+              if (!string.IsNullOrEmpty(validOsList) && !validOsList.Split(',').Any(os => os == "windows" || os == ContentDownloader.GetSteamOS())) continue;
+
+              ProviderItemMap[entry.Key] = GetProviderItem(entry.Key.ToString(), entry.Value.KeyValues);
 
               if (installedAppIdsToVersion.TryGetValue(entry.Key.ToString(), out var item))
               {


### PR DESCRIPTION
This should resolve the problem discovered with Civilization IV: Beyond the Sword

the package sold in store contains two same games, one is only for windows, the other is only for mac