### PR TITLE
Fix misidentifying the main OS drive as an external one in some conditions

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -13,7 +13,7 @@ static partial class Disk
 
     public static bool IsMountPointMainDisk(string mountPoint)
     {
-        return mountPoint == "/" || mountPoint.StartsWith("/home") || mountPoint.StartsWith("/var/home");
+        return mountPoint == "/" || mountPoint == "/sysroot" || mountPoint.StartsWith("/home") || mountPoint.StartsWith("/var/home");
     }
 
     public static async Task<string> GetMountPath(string? driveName = null)


### PR DESCRIPTION
When installing GameOS using our new experimental installer built with bootc-image-builder, there is no `/var/home` mount which is how the main OS drive was being identified.

Added `/sysroot` as an option. The main OS drive is always mounted to `/sysroot`.

Tested on an rpm-ostree system (installed with the current installer) and on a pure bootc system installed using our new installer.

Tested by installing a Steam game, playing the game, and uninstalling it. All worked successfully. 