### PR TITLE
fix: provide eula url with requested locale if supported

### DIFF
--- a/SteamBus.App/src/Core/Locale.cs
+++ b/SteamBus.App/src/Core/Locale.cs
@@ -1,0 +1,27 @@
+
+
+static class Locale
+{
+    public static string LocaleToSteamCode(string locale)
+    {
+        return locale switch
+        {
+            "en-US" => "english",
+            "fr-FR" => "french",
+            "de-DE" => "german",
+            "it-IT" => "italian",
+            "ko-KR" => "korean",
+            "pl-PL" => "polish",
+            "pt-BR" => "portugese",
+            "ru-RU" => "russian",
+            "zh-CN" => "schinese",
+            "zh-TW" => "tchinese",
+            "es-ES" => "spanish",
+            "ja-JP" => "japanese",
+            "ar" => "arabic",
+            "bg-BG" => "bulgarian",
+            "el-GR" => "greek",
+            _ => "english",
+        };
+    }
+}

--- a/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
+++ b/SteamBus.App/src/SteamBus.DBus/SteamClient.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Xdg.Directories;
 using Steam.Config;
 using Steam.Cloud;
+using System.Web;
 
 namespace SteamBus.DBus;
 
@@ -901,6 +902,13 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
       if (id == null || url == null)
         continue;
 
+      var uri = new Uri(url);
+      var query = HttpUtility.ParseQueryString(uri.Query);
+      query["eulaLang"] = Locale.LocaleToSteamCode(locale);
+      var ub = new UriBuilder(uri);
+      ub.Query = query.ToString();
+      url = ub.Uri.ToString();
+
       result.Add(new EulaEntry
       {
         Id = id,
@@ -909,7 +917,7 @@ class DBusSteamClient : IDBusSteamClient, IPlaytronPlugin, IAuthPasswordFlow, IA
         Url = url,
         Body = "",
         Country = allowedCountries?.AsString() ?? "",
-        Language = "",
+        Language = locale,
       });
     }
 


### PR DESCRIPTION
This implements a small utility that lets us translate locales to steam locale. 
Just the ones supported in GameOS and some additional ones from the top of the list https://partner.steamgames.com/doc/store/localization/languages