### PR TITLE
fix: map steam locales to xx-XX format when interacting with playserve

### DIFF
--- a/SteamBus.App/src/Core/Locale.cs
+++ b/SteamBus.App/src/Core/Locale.cs
@@ -1,5 +1,3 @@
-
-
 static class Locale
 {
     public static string LocaleToSteamCode(string locale)
@@ -10,18 +8,73 @@ static class Locale
             "fr-FR" => "french",
             "de-DE" => "german",
             "it-IT" => "italian",
-            "ko-KR" => "korean",
+            "ko-KR" => "koreana",
             "pl-PL" => "polish",
-            "pt-BR" => "portugese",
+            "pt-BR" => "portuguese",
             "ru-RU" => "russian",
             "zh-CN" => "schinese",
             "zh-TW" => "tchinese",
             "es-ES" => "spanish",
             "ja-JP" => "japanese",
-            "ar" => "arabic",
+
+            "arabic" => "ar",
             "bg-BG" => "bulgarian",
+            "cs-CZ" => "czech",
+            "da-DK" => "danish",
+            "nl-NL" => "dutch",
+            "fi-FI" => "finnish",
             "el-GR" => "greek",
+            "hu-HU" => "hungarian",
+            "id-ID" => "indonesian",
+            "no-NO" => "norwegian",
+            // "pt-BR" => "brazilian",
+            "ro-RO" => "romanian",
+            "es-419" => "latam",
+            "sv-SE" => "swedish",
+            "th-TH" => "thai",
+            "tr-TR" => "turkish",
+            "uk-UA" => "ukrainian",
+            "vi-VN" => "vietnamese",
             _ => "english",
+        };
+    }
+
+    public static string? SteamCodeToLocale(string? steamCode)
+    {
+        return steamCode switch
+        {
+            "english" => "en-US",
+            "french" => "fr-FR",
+            "german" => "de-DE",
+            "italian" => "it-IT",
+            "koreana" => "ko-KR",
+            "polish" => "pl-PL",
+            "portuguese" => "pt-BR",
+            "brazilian" => "pt-BR",
+            "russian" => "ru-RU",
+            "schinese" => "zh-CN",
+            "tchinese" => "zh-TW",
+            "spanish" => "es-ES",
+            "japanese" => "ja-JP",
+
+            "arabic" => "ar",
+            "bulgarian" => "bg-BG",
+            "czech" => "cs-CZ",
+            "danish" => "da-DK",
+            "dutch" => "nl-NL",
+            "finnish" => "fi-FI",
+            "greek" => "el-GR",
+            "hungarian" => "hu-HU",
+            "indonesian" => "id-ID",
+            "norwegian" => "no-NO",
+            "romanian" => "ro-RO",
+            "latam" => "es-419",
+            "swedish" => "sv-SE",
+            "thai" => "th-TH",
+            "turkish" => "tr-TR",
+            "ukrainian" => "uk-UA",
+            "vietnamese" => "vi-VN",
+            _ => null
         };
     }
 }

--- a/SteamBus.App/src/Playtron.Plugin/LibraryProvider.cs
+++ b/SteamBus.App/src/Playtron.Plugin/LibraryProvider.cs
@@ -123,7 +123,7 @@ public class InstallOption
 public class InstallOptions
 {
   public string branch = "public";
-  public string language = "english";
+  public string language = "en-US";
   public string version = "";
   public string os = "";
   public string architecture = "";

--- a/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
+++ b/SteamBus.App/src/Steam.Config/DepotConfigStore.cs
@@ -990,7 +990,7 @@ public class DepotConfigStore
             appId = appId,
             installDir = installDir,
             branch = branch,
-            language = data[KEY_USER_CONFIG][KEY_CONFIG_LANGUAGE]?.AsString() ?? "english",
+            language = Locale.SteamCodeToLocale(data[KEY_USER_CONFIG][KEY_CONFIG_LANGUAGE]?.AsString()) ?? "en-US",
             version = data[KEY_BUILD_ID].AsString() ?? "",
             os = os,
             architecture = "",
@@ -1022,8 +1022,8 @@ public class DepotConfigStore
                 var installPath = GetInstallDirectory(entry.Key)!;
                 var disabledDlc = (entry.Value[KEY_USER_CONFIG]?[KEY_CONFIG_DISABLED_DLC]?.AsString() ?? "").Split(',');
                 var branch = entry.Value[KEY_MOUNTED_CONFIG]?[KEY_CONFIG_BETA_KEY]?.AsString() ?? AppDownloadOptions.DEFAULT_BRANCH;
-                var language = entry.Value[KEY_MOUNTED_CONFIG]?[KEY_CONFIG_LANGUAGE]?.AsString() ?? "english";
-
+                var language = entry.Value[KEY_MOUNTED_CONFIG]?[KEY_CONFIG_LANGUAGE]?.AsString();
+                language = Locale.SteamCodeToLocale(language) ?? "en-US";
                 var contentDownloader = new ContentDownloader(steamSession, this);
                 var installOptions = new InstallOptions
                 {

--- a/SteamBus.App/src/Steam.Config/InstallScript.cs
+++ b/SteamBus.App/src/Steam.Config/InstallScript.cs
@@ -234,7 +234,7 @@ public class InstallScript
                             {
                                 dwords.Add(new PostInstallRegistryValue
                                 {
-                                    Language = keyOrLanguage.Name,
+                                    Language = Locale.SteamCodeToLocale(keyOrLanguage.Name),
                                     Group = groupName!,
                                     Key = key.Name ?? "",
                                     Value = ReplaceDynamicVariables(installDir, key.AsString() ?? "", true)!,
@@ -244,7 +244,7 @@ public class InstallScript
                             {
                                 strings.Add(new PostInstallRegistryValue
                                 {
-                                    Language = keyOrLanguage.Name,
+                                    Language = Locale.SteamCodeToLocale(keyOrLanguage.Name),
                                     Group = groupName!,
                                     Key = key.Name ?? "",
                                     Value = ReplaceDynamicVariables(installDir, key.AsString() ?? "", true)!,

--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -267,7 +267,10 @@ public class ContentDownloader
         if (supported == null || supported.AsString() != "true")
           continue;
 
-        languageOptions.Add(language);
+        var localeCode = Locale.SteamCodeToLocale(language);
+        if (localeCode == null)
+          continue;
+        languageOptions.Add(localeCode);
       }
     }
 

--- a/SteamBus.App/src/Steam.Content/DownloadConfig.cs
+++ b/SteamBus.App/src/Steam.Content/DownloadConfig.cs
@@ -71,7 +71,7 @@ public class AppDownloadOptions
     this.Branch = string.IsNullOrEmpty(options.branch) ? DEFAULT_BRANCH : options.branch;
     this.Os = string.IsNullOrEmpty(options.os) ? GetSteamOS() : options.os;
     this.Arch = string.IsNullOrEmpty(options.architecture) ? GetSteamArch() : options.architecture;
-    this.Language = string.IsNullOrEmpty(options.language) ? "english" : options.language;
+    this.Language = string.IsNullOrEmpty(options.language) ? "english" : Locale.LocaleToSteamCode(options.language);
     this.VerifyAll = options.verify;
     this.LowViolence = false;
     this.IsUgc = false;


### PR DESCRIPTION
when reviewing please consider also double checking I covered all endpoints that include locales in input or output