### PR TITLE
fix(Disk): mount point parsing

### DIFF
--- a/SteamBus.App/src/Core/Disk.cs
+++ b/SteamBus.App/src/Core/Disk.cs
@@ -47,7 +47,7 @@ static partial class Disk
       }
 
       string device = parts[0];
-      string mountPoint = parts[1];
+      string mountPoint = parts[1].Replace("\\040", " ").Replace("\\011", "\t").Replace("\\012", "\n").Replace("\\134", "\\");
       string filesystem = parts[2];
       string options = parts[3];
 


### PR DESCRIPTION
Special characters in `/proc/mounts` were not being parsed and causing issues with, for example, external media that contained a space character in its mount path.

This addresses that.