### PR TITLE
fix: supported locales can have a value of true or 1

### DIFF
--- a/SteamBus.App/src/Steam.Content/ContentDownloader.cs
+++ b/SteamBus.App/src/Steam.Content/ContentDownloader.cs
@@ -264,7 +264,7 @@ public class ContentDownloader
           continue;
 
         var supported = languageSection["supported"];
-        if (supported == null || supported.AsString() != "true")
+        if (supported == null || (supported.AsString() != "true" && supported.AsString() != "1"))
           continue;
 
         languageOptions.Add(language);


### PR DESCRIPTION
This fixes some games installing in the wrong language. 

You can see the issue by opening the steam client with `-console` and running app_info_print 220440: 

```

		"supported_languages"
		{
			"english"
			{
				"supported"		"1"
				"full_audio"		"1"
				"subtitles"		"true"
			}
			"german"
			{
				"supported"		"1"
				"full_audio"		"1"
				"subtitles"		"true"
			}
			"french"
			{
				"supported"		"1"
				"full_audio"		"1"
				"subtitles"		"true"
			}
			"italian"
			{
				"supported"		"1"
				"full_audio"		"1"
				"subtitles"		"true"
			}
			"spanish"
			{
				"supported"		"1"
				"full_audio"		"1"
				"subtitles"		"true"
			}
			"dutch"
			{
				"supported"		"true"
				"subtitles"		"true"
			}
			"polish"
			{
				"supported"		"true"
				"subtitles"		"true"
			}
			"brazilian"
			{
				"supported"		"true"
				"subtitles"		"true"
			}
			"russian"
			{
				"supported"		"true"
				"subtitles"		"true"
			}
		}
```
There is a mixture of "1" and "true", with Dutch being the 1st language using true (DmC ends up being installed in Dutch)